### PR TITLE
Added flag to filter by no prereqs

### DIFF
--- a/src/components/ClassTable.tsx
+++ b/src/components/ClassTable.tsx
@@ -146,6 +146,7 @@ const CLASS_FLAGS_1: FilterGroup = [
   ["cih", "CI-H"],
   ["fits", "Fits schedule"],
   ["nofinal", "No final"],
+  ["nopreq", "No prereq"]
 ];
 
 /** List of hidden filter IDs, their displayed names, and image path, if any. */

--- a/src/lib/class.ts
+++ b/src/lib/class.ts
@@ -33,6 +33,7 @@ export type Flags = {
   notcih: boolean;
   final: boolean;
   nofinal: boolean;
+  nopreq: boolean;
   le9units: boolean;
   half: number | false;
   limited: boolean;
@@ -285,6 +286,7 @@ export class Class {
       notcih: !this.rawClass.ci && !this.rawClass.cw,
       final: this.rawClass.f,
       nofinal: !this.rawClass.f,
+      nopreq: this.rawClass.pr === "None",
       le9units: this.totalUnits <= 9,
       half: this.rawClass.hf,
       limited: this.rawClass.lm,


### PR DESCRIPTION
I felt that this would be a helpful feature for frosh looking for classes to take without pre-reqs.