### PR TITLE
Add form to color picker

### DIFF
--- a/src/components/ActivityButtons.tsx
+++ b/src/components/ActivityButtons.tsx
@@ -121,19 +121,22 @@ function ActivityColor(props: {
 
   const isError = input !== "" ? canonicalizeColor(input) === undefined : false;
 
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const canon = canonicalizeColor(input);
+    if (canon) {
+      setColor(canon);
+      setInput("");
+    }
+  }
+
   return (
     <Flex gap={2}>
       <HexColorPicker color={color} onChange={setColor} />
       <Flex direction="column" gap={2}>
         <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            const canon = canonicalizeColor(input);
-            if (canon) {
-              setColor(canon);
-              setInput("");
-            }
-          }}
+          onSubmit={handleSubmit}
+          onBlur={handleSubmit}
         >
           <Input
             // Wide enough to hold everything, but keeps buttons below small

--- a/src/components/ActivityButtons.tsx
+++ b/src/components/ActivityButtons.tsx
@@ -20,8 +20,6 @@ import { textColor } from "../lib/colors";
 import { WEEKDAY_STRINGS, TIMESLOT_STRINGS, Slot } from "../lib/dates";
 import { State } from "../lib/state";
 
-import { ColorButton } from "./SelectedActivities";
-
 /**
  * A button that toggles the active value, and is outlined if active, solid
  * if not.

--- a/src/lib/colors.ts
+++ b/src/lib/colors.ts
@@ -134,5 +134,26 @@ export function textColor(color: string): string {
   return brightness > 128 ? "#000000" : "#ffffff";
 }
 
+/** Return a standard #AABBCC representation from an input color */
+export function canonicalizeColor(code: string): string | undefined {
+  code = code.trim();
+  let fiveSix = code.match(/^#?[0-9a-f]{5,6}$/gi);
+  if (fiveSix) {
+    return code.startsWith("#") ? code : `#${code}`;
+  }
+  let triplet = code.match(/^#?[0-9a-f]{3}$/gi);
+  if (triplet) {
+    const expanded =
+      code.slice(-3, -2) +
+      code.slice(-3, -2) +
+      code.slice(-2, -1) +
+      code.slice(-2, -1) +
+      code.slice(-1) +
+      code.slice(-1);
+    return code.startsWith("#") ? expanded : `#${expanded}`;
+  }
+  return undefined;
+}
+
 /** The Google calendar background color. */
 export const CALENDAR_COLOR = "#DB5E45";


### PR DESCRIPTION
Also update button behaviour so that only manual section assignment or color assignment is toggled at once. Renaming and color assignment are deliberately left simultaneous in the case of a custom activity.