### PR TITLE
Use old course 6 numbers for HKN

### DIFF
--- a/src/lib/class.ts
+++ b/src/lib/class.ts
@@ -418,7 +418,7 @@ export class Class {
       extraUrls.unshift({ label: "More Info", url: this.rawClass.u });
     }
     if (this.course === "6") {
-      const number = this.oldNumber ? this.oldNumber : this.number;
+      const number = this.oldNumber ?? this.number;
       extraUrls.push({
         label: "HKN Underground Guide",
         url: `https://underground-guide.mit.edu/search?q=${number}`,

--- a/src/lib/class.ts
+++ b/src/lib/class.ts
@@ -418,10 +418,9 @@ export class Class {
       extraUrls.unshift({ label: "More Info", url: this.rawClass.u });
     }
     if (this.course === "6") {
-      const number = this.oldNumber ?? this.number;
       extraUrls.push({
         label: "HKN Underground Guide",
-        url: `https://underground-guide.mit.edu/search?q=${number}`,
+        url: `https://underground-guide.mit.edu/search?q=${this.oldNumber ?? this.number}`,
       });
     }
     if (this.course === "18") {

--- a/src/lib/class.ts
+++ b/src/lib/class.ts
@@ -418,9 +418,10 @@ export class Class {
       extraUrls.unshift({ label: "More Info", url: this.rawClass.u });
     }
     if (this.course === "6") {
+      const number = this.oldNumber ? this.oldNumber : this.number;
       extraUrls.push({
         label: "HKN Underground Guide",
-        url: `https://underground-guide.mit.edu/search?q=${this.number}`,
+        url: `https://underground-guide.mit.edu/search?q=${number}`,
       });
     }
     if (this.course === "18") {


### PR DESCRIPTION
Use old course 6 course numbers when available for links to HKN Underground Guide.

Fixes #10.