### PR TITLE
Display classes with arranged units correctly

### DIFF
--- a/scrapers/fireroad.py
+++ b/scrapers/fireroad.py
@@ -161,17 +161,20 @@ def get_course_data(courses, course):
 
     # hh, ha, hs, he, ci, cw, re, la, pl
     raw_class.update(parse_attributes(course))
-
     raw_class.update(
         {
             "u1": course["lecture_units"],
             "u2": course["lab_units"],
             "u3": course["preparation_units"],
             "le": course["level"],
+            "vu": course["is_variable_units"],
             "sa": ", ".join(course.get("joint_subjects", [])),
             "mw": ", ".join(course.get("meets_with_subjects", [])),
         }
     )
+    # This should be the case with variable-units classes, but just to make sure.
+    if raw_class["vu"]:
+        raw_class["u1"] = raw_class["u2"] = raw_class["u3"] = 0
 
     # t, pr
     raw_class.update(parse_terms(course))

--- a/src/components/ActivityDescription.tsx
+++ b/src/components/ActivityDescription.tsx
@@ -100,6 +100,11 @@ function ClassTypes(props: { cls: Class, state: State }) {
     ) : (
       ""
     );
+  
+  const unitsDescription =
+    cls.isVariableUnits
+      ? "Units arranged"
+      : `${totalUnits} units: ${units.join("-")}`;
 
   return (
     <Flex gap={4} align="center">
@@ -112,7 +117,7 @@ function ClassTypes(props: { cls: Class, state: State }) {
         {halfType}
       </Flex>
       <Text>
-        {totalUnits} units: {units.join("-")}
+        {unitsDescription}
       </Text>
       {flags.final ? <Text>Has final</Text> : null}
     </Flex>

--- a/src/lib/class.ts
+++ b/src/lib/class.ts
@@ -270,6 +270,11 @@ export class Class {
     return [this.rawClass.u1, this.rawClass.u2, this.rawClass.u3];
   }
 
+  /** Returns whether this class has a variable/arranged number of units. */
+  get isVariableUnits(): boolean {
+    return this.rawClass.vu;
+  }
+
   /** Total class units, usually 12. */
   get totalUnits(): number {
     return this.rawClass.u1 + this.rawClass.u2 + this.rawClass.u3;
@@ -321,7 +326,7 @@ export class Class {
       final: this.rawClass.f,
       nofinal: !this.rawClass.f,
       nopreq: this.rawClass.pr === "None",
-      le9units: this.totalUnits <= 9,
+      le9units: this.totalUnits <= 9 && !this.isVariableUnits,
       half: this.rawClass.hf,
       limited: this.rawClass.lm,
     };
@@ -370,17 +375,31 @@ export class Class {
   } {
     const suffixes: Array<string> = [];
     const messages: Array<string> = [];
-    if (this.rawClass.h === 0) {
-      suffixes.push("*");
-      messages.push(
-        "* Class does not have evaluations, so its hours were set to units."
-      );
-    }
     if (this.rawClass.tb) {
       suffixes.push("+");
       messages.push(
         "+ Class has at least one section yet to be scheduled—check course catalog."
       );
+    }
+    if (this.rawClass.vu) {
+      if (this.rawClass.h === 0) {
+        suffixes.push("^");
+        messages.push(
+          "^ This class has an arranged number of units and no evaluations, so it was not counted towards total units or hours."
+        )
+      } else {
+        suffixes.push("#");
+        messages.push(
+          "# This class has an arranged number of units and its units were not counted in the total."
+        )
+      }
+    } else {
+      if (this.rawClass.h === 0) {
+        suffixes.push("*");
+        messages.push(
+          "* Class does not have evaluations, so its hours were set to units."
+        );
+      }
     }
     return { suffix: suffixes.join(""), messages };
   }

--- a/src/lib/rawClass.ts
+++ b/src/lib/rawClass.ts
@@ -61,6 +61,10 @@ export type RawClass = {
   u2: number;
   /** Outside class units */
   u3: number;
+  /** Does this class have an arranged number of units?
+   * If true, u1, u2, u3 are set to zero.
+   */
+  vu: boolean;
 
   /** Level: "U" undergrad, "G" grad */
   le: "U" | "G";

--- a/src/lib/rawClass.ts
+++ b/src/lib/rawClass.ts
@@ -61,7 +61,8 @@ export type RawClass = {
   u2: number;
   /** Outside class units */
   u3: number;
-  /** Does this class have an arranged number of units?
+  /**
+   * Does this class have an arranged number of units?
    * If true, u1, u2, u3 are set to zero.
    */
   vu: boolean;


### PR DESCRIPTION
Before, classes that have an arranged number of units will simply display and behave as classes with 0 units. This commit displays them as "units arranged", and shows warnings when counting total units and hours if these classes are present.