### PR TITLE
Switch from ics to ical-generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@types/react": "^17.0.48",
         "@types/react-dom": "^17.0.17",
         "html-entities": "^2.3.3",
-        "ics": "^2.41.0",
+        "ical-generator": "^6.0.0",
         "msgpack-lite": "^0.1.26",
         "nanoid": "^3.3.4",
         "react": "^18.2.0",
@@ -34,6 +34,7 @@
         "react-dom": "^18.2.0",
         "react-scripts": "^5.0.1",
         "sass": "^1.54.4",
+        "timezones-ical-library": "^1.7.2",
         "typescript": "^4.7.4"
       },
       "engines": {
@@ -4492,6 +4493,16 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@touch4it/ical-timezones": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@touch4it/ical-timezones/-/ical-timezones-1.9.0.tgz",
+      "integrity": "sha512-UAiZMrFlgMdOIaJDPsKu5S7OecyMLr3GGALJTYkRgHmsHAA/8Ixm1qD09ELP2X7U1lqgrctEgvKj9GzMbczC+g==",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@trysound/sax": {
@@ -9599,6 +9610,56 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/ical-generator": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ical-generator/-/ical-generator-6.0.0.tgz",
+      "integrity": "sha512-LBSyAQiWKYBjDBOYamPDhYfXvuzMCijK7vLtGQqFjxqDOb5sj4LtW1JyeesJg5U2bK+SQaboBYH4TzxBq1gnDw==",
+      "dependencies": {
+        "uuid-random": "^1.3.2"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@touch4it/ical-timezones": ">=1.6.0",
+        "@types/luxon": ">= 1.26.0",
+        "@types/mocha": ">= 8.2.1",
+        "dayjs": ">= 1.10.0",
+        "luxon": ">= 1.26.0",
+        "moment": ">= 2.29.0",
+        "moment-timezone": ">= 0.5.33",
+        "rrule": ">= 2.6.8"
+      },
+      "peerDependenciesMeta": {
+        "@touch4it/ical-timezones": {
+          "optional": true
+        },
+        "@types/luxon": {
+          "optional": true
+        },
+        "@types/mocha": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-timezone": {
+          "optional": true
+        },
+        "rrule": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -9608,15 +9669,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ics": {
-      "version": "2.41.0",
-      "resolved": "https://registry.npmjs.org/ics/-/ics-2.41.0.tgz",
-      "integrity": "sha512-6oleMfOpdBIrZGMNrTutwW7eFwua8lOkymDNxMXlsVF00HghqH+I3S6frt3a2rfjXTlkI0qiY2rnsKP2JQ9vJA==",
-      "dependencies": {
-        "nanoid": "^3.1.23",
-        "yup": "^0.32.9"
       }
     },
     "node_modules/icss-utils": {
@@ -12393,11 +12445,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -12717,11 +12764,6 @@
       "bin": {
         "multicast-dns": "cli.js"
       }
-    },
-    "node_modules/nanoclone": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
-      "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
@@ -14653,11 +14695,6 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
-    },
-    "node_modules/property-expr": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
-      "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA=="
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -16598,6 +16635,14 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
     },
+    "node_modules/timezones-ical-library": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/timezones-ical-library/-/timezones-ical-library-1.7.2.tgz",
+      "integrity": "sha512-QxZd7SowEZ5/Kg6ZJuBYI2BUqmyDj5HdI9RSWSQtzYm3UeVd5ziFpEBjw715zCzQca6V4xIiHc5j95tUzDTOyg==",
+      "engines": {
+        "node": ">=14.20.0"
+      }
+    },
     "node_modules/tiny-invariant": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
@@ -16639,11 +16684,6 @@
       "engines": {
         "node": ">=0.6"
       }
-    },
-    "node_modules/toposort": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
-      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
     },
     "node_modules/tough-cookie": {
       "version": "4.0.0",
@@ -17002,6 +17042,11 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/uuid-random": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/uuid-random/-/uuid-random-1.3.2.tgz",
+      "integrity": "sha512-UOzej0Le/UgkbWEO8flm+0y+G+ljUon1QWTEZOq1rnMAsxo2+SckbiZdKzAHHlVh6gJqI1TjC/xwgR50MuCrBQ=="
     },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
@@ -17949,23 +17994,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yup": {
-      "version": "0.32.11",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
-      "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
-      "dependencies": {
-        "@babel/runtime": "^7.15.4",
-        "@types/lodash": "^4.14.175",
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21",
-        "nanoclone": "^0.2.1",
-        "property-expr": "^2.0.4",
-        "toposort": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=10"
       }
     }
   },
@@ -21045,6 +21073,13 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+    },
+    "@touch4it/ical-timezones": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@touch4it/ical-timezones/-/ical-timezones-1.9.0.tgz",
+      "integrity": "sha512-UAiZMrFlgMdOIaJDPsKu5S7OecyMLr3GGALJTYkRgHmsHAA/8Ixm1qD09ELP2X7U1lqgrctEgvKj9GzMbczC+g==",
+      "optional": true,
+      "peer": true
     },
     "@trysound/sax": {
       "version": "0.2.0",
@@ -24855,21 +24890,20 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
     },
+    "ical-generator": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ical-generator/-/ical-generator-6.0.0.tgz",
+      "integrity": "sha512-LBSyAQiWKYBjDBOYamPDhYfXvuzMCijK7vLtGQqFjxqDOb5sj4LtW1JyeesJg5U2bK+SQaboBYH4TzxBq1gnDw==",
+      "requires": {
+        "uuid-random": "^1.3.2"
+      }
+    },
     "iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
-      }
-    },
-    "ics": {
-      "version": "2.41.0",
-      "resolved": "https://registry.npmjs.org/ics/-/ics-2.41.0.tgz",
-      "integrity": "sha512-6oleMfOpdBIrZGMNrTutwW7eFwua8lOkymDNxMXlsVF00HghqH+I3S6frt3a2rfjXTlkI0qiY2rnsKP2JQ9vJA==",
-      "requires": {
-        "nanoid": "^3.1.23",
-        "yup": "^0.32.9"
       }
     },
     "icss-utils": {
@@ -26861,11 +26895,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -27109,11 +27138,6 @@
         "dns-packet": "^5.2.2",
         "thunky": "^1.0.2"
       }
-    },
-    "nanoclone": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
-      "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
     },
     "nanoid": {
       "version": "3.3.4",
@@ -28327,11 +28351,6 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
-    },
-    "property-expr": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
-      "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA=="
     },
     "proxy-addr": {
       "version": "2.0.7",
@@ -29747,6 +29766,11 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
     },
+    "timezones-ical-library": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/timezones-ical-library/-/timezones-ical-library-1.7.2.tgz",
+      "integrity": "sha512-QxZd7SowEZ5/Kg6ZJuBYI2BUqmyDj5HdI9RSWSQtzYm3UeVd5ziFpEBjw715zCzQca6V4xIiHc5j95tUzDTOyg=="
+    },
     "tiny-invariant": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
@@ -29779,11 +29803,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
-    },
-    "toposort": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
-      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
     },
     "tough-cookie": {
       "version": "4.0.0",
@@ -30028,6 +30047,11 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
+    "uuid-random": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/uuid-random/-/uuid-random-1.3.2.tgz",
+      "integrity": "sha512-UOzej0Le/UgkbWEO8flm+0y+G+ljUon1QWTEZOq1rnMAsxo2+SckbiZdKzAHHlVh6gJqI1TjC/xwgR50MuCrBQ=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -30768,20 +30792,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
-    },
-    "yup": {
-      "version": "0.32.11",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
-      "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
-      "requires": {
-        "@babel/runtime": "^7.15.4",
-        "@types/lodash": "^4.14.175",
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21",
-        "nanoclone": "^0.2.1",
-        "property-expr": "^2.0.4",
-        "toposort": "^2.0.2"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@types/react": "^17.0.48",
     "@types/react-dom": "^17.0.17",
     "html-entities": "^2.3.3",
-    "ics": "^2.41.0",
+    "ical-generator": "^6.0.0",
     "msgpack-lite": "^0.1.26",
     "nanoid": "^3.3.4",
     "react": "^18.2.0",
@@ -30,6 +30,7 @@
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
     "sass": "^1.54.4",
+    "timezones-ical-library": "^1.7.2",
     "typescript": "^4.7.4"
   },
   "scripts": {


### PR DESCRIPTION
Fixes #26. The `ics` package [does not support exporting timezone-aware ICS files][1]; switch to `ical-generator` (along with `timezones-ical-library`) to store times in local time (which adapts to DST).

[1]: https://github.com/adamgibbons/ics/pull/112