### PR TITLE
Allow the Matrix class group chat picker (and potentially other SIPB projects) to ask Hydrant for the user's class list

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -103,7 +103,8 @@ function useHydrant(): {
  */
 const ALLOWED_INTEGRATION_CALLBACKS = [
   "http://localhost:5173/classes/hydrantCallback",
-  "https://matrix.mit.edu/classes/hydrantCallback"
+  "https://matrix.mit.edu/classes/hydrantCallback",
+  "https://uplink.mit.edu/classes/hydrantCallback",
 ];
 
 /** The application entry. */

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -102,7 +102,6 @@ function useHydrant(): {
  * could be implemented.
  */
 const ALLOWED_INTEGRATION_CALLBACKS = [
-  "http://localhost:5173/classes/hydrantCallback",
   "https://matrix.mit.edu/classes/hydrantCallback",
   "https://uplink.mit.edu/classes/hydrantCallback",
 ];

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -136,7 +136,7 @@ function HydrantApp() {
       .join('');
     const filledCallback = `${callback}?hydrant=true${encodedClasses}`;
     window.location.replace(filledCallback);
-  }, [hydrant]);
+  }, [hydrant, hasIntegrationCallback, hash]);
 
   const [isExporting, setIsExporting] = useState(false);
   // TODO: fix gcal export


### PR DESCRIPTION
The usage flow should be the following:

* External application redirects to `https://hydrant.mit.edu/#/export?callback=http://localhost:5173/hydrantCallback`
* If the callback is a (currently hardcoded) list of allowed callbacks, Hydrant will redirect back to it and provide it the user's class list like so: `http://localhost:5173/hydrantCallback?hydrant=true&class=11.C35&class=6.1210&class=6.1910`