### PR TITLE
overhaul scrapers/math_dept.py

### DIFF
--- a/scrapers/math_dept.py
+++ b/scrapers/math_dept.py
@@ -48,6 +48,10 @@ def parse_when(when):
 def test_parse_when():
     """
     Test cases for parse_when
+
+    Args: none
+
+    Returns: none
     """
     assert parse_when("F10:30-12") == ("F", "10.30-12")
     assert parse_when("MW1") == ("MW", "1")
@@ -102,6 +106,11 @@ def make_section_override(timeslots, room):
 def get_rows():
     """
     Scrapes rows from https://math.mit.edu/academics/classes.html
+
+    Args: none
+
+    Returns:
+    * bs4.element.ResultSet: The rows of the table listing classes
     """
     response = requests.get("https://math.mit.edu/academics/classes.html", timeout = 1)
     soup = BeautifulSoup(response.text, features="lxml")
@@ -112,6 +121,12 @@ def get_rows():
 def parse_subject(subject):
     """
     Parses the subject
+
+    Args:
+    * subject (str): The subject name to parse
+
+    Returns:
+    * subjects (list[str]): A clean list of subjects corresponding to that subject.
     """
     # remove "J" from joint subjects
     subject = subject.replace("J", "")
@@ -130,6 +145,12 @@ def parse_subject(subject):
 def parse_row(row):
     """
     Parses the provided row
+
+    Args:
+    * row (bs4.element.Tag): The row that needs to be parsed.
+
+    Returns:
+    * dict[str, dict[str, list]]: The parsed row 
     """
     result = {}
 
@@ -159,6 +180,10 @@ def parse_row(row):
 def run():
     """
     The main entry point
+
+    Args: none
+
+    Returns: dict[str, dict[str, list]]: Schedules for classes offered by the math dept
     """
     rows = get_rows()
 

--- a/scrapers/math_dept.py
+++ b/scrapers/math_dept.py
@@ -9,6 +9,7 @@ Functions:
 * parse_many_timeslots(days, times)
 * make_raw_sections(days, times, room):
 * make_section_override(timeslots, room)
+* get_rows()
 * run()
 """
 
@@ -96,14 +97,21 @@ def make_section_override(timeslots, room):
     # lol this is wrong
     # return [[section, room] for section in timeslots]
 
-def run():
+def get_rows():
     """
-    The main entry point
+    Scrapes rows from https://math.mit.edu/academics/classes.html
     """
     response = requests.get("https://math.mit.edu/academics/classes.html")
     soup = BeautifulSoup(response.text, features="lxml")
     course_list = soup.find("ul", {"class": "course-list"})
     rows = course_list.findAll("li", recursive=False)
+    return rows
+
+def run():
+    """
+    The main entry point
+    """
+    rows = get_rows()
 
     overrides = {}
 

--- a/scrapers/math_dept.py
+++ b/scrapers/math_dept.py
@@ -1,7 +1,6 @@
 """
 This isn't run automatically, but it is a temporary workaround to the math classes being wrong.
-Used to generate the math overrides in package.py.
-There is a large amount of main code.
+Was used to generate the math overrides in package.py; currently unnecessary.
 
 Functions:
 * parse_when(when)
@@ -64,7 +63,7 @@ def parse_many_timeslots(days, times):
 
     Args:
     * day (str): A list of days
-    * times (str): The timesloot
+    * times (str): The timeslot
 
     Returns:
     * list[list[int]]: All of the parsed timeslots, as a list
@@ -93,7 +92,7 @@ def make_section_override(timeslots, room):
     Makes a section override
 
     Args:
-    * timeslots
+    * timeslots (list[list[int]]): The timeslots of the section
     * room (str): The room
 
     Returns:
@@ -150,7 +149,7 @@ def parse_row(row):
     * row (bs4.element.Tag): The row that needs to be parsed.
 
     Returns:
-    * dict[str, dict[str, list]]: The parsed row 
+    * dict[str, dict[str, list[Union[list[list[int]], str]]]]: The parsed row 
     """
     result = {}
 
@@ -183,7 +182,8 @@ def run():
 
     Args: none
 
-    Returns: dict[str, dict[str, list]]: Schedules for classes offered by the math dept
+    Returns:
+    * dict[str, dict[str, list[Union[list[list[int]], str]]]]: All the schedules
     """
     rows = get_rows()
 

--- a/scrapers/math_dept.py
+++ b/scrapers/math_dept.py
@@ -65,7 +65,7 @@ def parse_many_timeslots(days, times):
     * list[list[int]]: All of the parsed timeslots, as a list
     """
     # parse timeslot wants only one letter
-    return [parse_timeslot(day, times) for day in days]
+    return [parse_timeslot(day, times, False) for day in days]
 
 
 def make_raw_sections(days, times, room):

--- a/scrapers/math_dept.py
+++ b/scrapers/math_dept.py
@@ -103,7 +103,7 @@ def get_rows():
     """
     Scrapes rows from https://math.mit.edu/academics/classes.html
     """
-    response = requests.get("https://math.mit.edu/academics/classes.html")
+    response = requests.get("https://math.mit.edu/academics/classes.html", timeout = 1)
     soup = BeautifulSoup(response.text, features="lxml")
     course_list = soup.find("ul", {"class": "course-list"})
     rows = course_list.findAll("li", recursive=False)

--- a/scrapers/math_dept.py
+++ b/scrapers/math_dept.py
@@ -10,10 +10,10 @@ Functions:
 * make_section_override(timeslots, room)
 """
 
-from bs4 import BeautifulSoup
-from fireroad import parse_timeslot, parse_section
 from pprint import pprint
+from bs4 import BeautifulSoup
 import requests
+from fireroad import parse_timeslot, parse_section
 
 # TODO: move this huge wall of code into its own function
 

--- a/scrapers/math_dept.py
+++ b/scrapers/math_dept.py
@@ -44,6 +44,7 @@ def parse_when(when):
     times = times.replace(":", ".")
     return days, times
 
+
 def test_parse_when():
     """
     Test cases for parse_when
@@ -102,6 +103,7 @@ def make_section_override(timeslots, room):
     # lol this is wrong
     # return [[section, room] for section in timeslots]
 
+
 def get_rows():
     """
     Scrapes rows from https://math.mit.edu/academics/classes.html
@@ -111,11 +113,12 @@ def get_rows():
     Returns:
     * bs4.element.ResultSet: The rows of the table listing classes
     """
-    response = requests.get("https://math.mit.edu/academics/classes.html", timeout = 1)
+    response = requests.get("https://math.mit.edu/academics/classes.html", timeout=1)
     soup = BeautifulSoup(response.text, features="lxml")
     course_list = soup.find("ul", {"class": "course-list"})
     rows = course_list.findAll("li", recursive=False)
     return rows
+
 
 def parse_subject(subject):
     """
@@ -141,6 +144,7 @@ def parse_subject(subject):
 
     return subjects
 
+
 def parse_row(row):
     """
     Parses the provided row
@@ -149,7 +153,7 @@ def parse_row(row):
     * row (bs4.element.Tag): The row that needs to be parsed.
 
     Returns:
-    * dict[str, dict[str, list[Union[list[list[int]], str]]]]: The parsed row 
+    * dict[str, dict[str, list[Union[list[list[int]], str]]]]: The parsed row
     """
     result = {}
 
@@ -176,6 +180,7 @@ def parse_row(row):
         assert parse_section(lecture_raw_sections) == lecture_sections[0]
     return result
 
+
 def run():
     """
     The main entry point
@@ -193,6 +198,7 @@ def run():
         overrides.update(parsed_row)
 
     return overrides
+
 
 if __name__ == "__main__":
     test_parse_when()

--- a/scrapers/math_dept.py
+++ b/scrapers/math_dept.py
@@ -186,7 +186,6 @@ def run():
     * dict[str, dict[str, list[Union[list[list[int]], str]]]]: All the schedules
     """
     rows = get_rows()
-
     overrides = {}
 
     for row in rows:

--- a/scrapers/math_dept.py
+++ b/scrapers/math_dept.py
@@ -10,6 +10,7 @@ Functions:
 * make_raw_sections(days, times, room):
 * make_section_override(timeslots, room)
 * get_rows()
+* parse_subject(subject)
 * parse_row(row)
 * run()
 """
@@ -108,12 +109,10 @@ def get_rows():
     rows = course_list.findAll("li", recursive=False)
     return rows
 
-def parse_row(row):
+def parse_subject(subject):
     """
-    Parses the provided row
+    Parses the subject
     """
-    result = {}
-    subject = row.find("div", {"class": "subject"}).text
     # remove "J" from joint subjects
     subject = subject.replace("J", "")
 
@@ -125,6 +124,17 @@ def parse_row(row):
     else:
         subjects = [subject]
     assert ["/" not in subject for subject in subjects]
+
+    return subjects
+
+def parse_row(row):
+    """
+    Parses the provided row
+    """
+    result = {}
+
+    subject = row.find("div", {"class": "subject"}).text
+    subjects = parse_subject(subject)
 
     where_when = row.find("div", {"class": "where-when"})
     when, where = where_when.findAll("div", recursive=False)


### PR DESCRIPTION
This is major overhaul of `scrapers/math_dept.py`. Even though I know it isn't actually being used in production, I still think it's good to make all the code as pretty and modular as possible for posterity.

More specifically, the main code in `math_dept.py` (all the random stuff that used to be non-indented) is now divided into:

* `run()`, the main entry point, which uses three other helper functions:
  * `get_rows()` for scraping
  * `parse_subject(subject)` to parse the title specifically
  * `parse_row(row)` to parse an individual row
* `test_parse_when()` as a sanity check that `parse_when(when)` works properly