### PR TITLE
Fix deploy action to use correct build directory

### DIFF
--- a/.github/workflows/autodeploy.yml
+++ b/.github/workflows/autodeploy.yml
@@ -24,5 +24,5 @@ jobs:
         with:
           name: built-site
           path: |
-            build
-            !build/latest.json
+            dist
+            !dist/latest.json


### PR DESCRIPTION
Exactly what it says on the title. Noticed hydrant.mit.edu was still using webpack, realized I forgot to change the deploy action