### PR TITLE
Update course 18 underground guide link to new site

### DIFF
--- a/src/lib/class.ts
+++ b/src/lib/class.ts
@@ -502,7 +502,7 @@ export class Class {
     if (this.course === "18") {
       extraUrls.push({
         label: "Course 18 Underground Guide",
-        url: `http://course18.guide/${this.number}-spring-2021.html`,
+        url: `https://mathguide.mit.edu/${this.number}`,
       });
     }
 


### PR DESCRIPTION
Fix broken link to the course 18 Underground guide. The underground guide is at [mathguide.mit.edu](https://mathguide.mit.edu) now. To view a specific class, go to, e.g., [mathguide.mit.edu/18.404](https://mathguide.mit.edu/18.404).

It used to be at [course18.guide](course18.guide), but the domain is no longer active. As a maintainer of the underground guide at [MIT UMA Tech](https://uma.mit.edu/resources), we work with [CoMM](https://web.mit.edu/comm/) to rewrite the site. Although the work is still in progress, it'd be great to update the link to ease class selection!