### PR TITLE
mark classes not offered regularly as not offered

### DIFF
--- a/scrapers/catalog.py
+++ b/scrapers/catalog.py
@@ -33,6 +33,10 @@ def is_not_offered_this_year(html):
     """
     if html.find(attrs={"src": "/icns/nooffer.gif"}):
         return True
+    if html.find(
+        text=re.compile("not offered regularly; consult department", re.IGNORECASE)
+    ):
+        return True
     return False
 
 


### PR DESCRIPTION
Fixes #110. Checks if a class says "not regularly offered; consult department" on the catalog and excludes it. There's probably a nicer way of doing this, so let me know!