### PR TITLE
Show latest term if term indicated by URL is invalid

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -57,7 +57,7 @@ function useHydrant(): {
   useEffect(() => {
     fetchNoCache<LatestTermInfo>("latestTerm.json").then((latestTerm) => {
       const params = new URLSearchParams(document.location.search);
-      const term = params.get("t") ?? latestTerm.semester.urlName;
+      const term = params.get("t") ?? "latest";
       fetchNoCache<SemesterData>(`${term}.json`)
         .then(({ classes, lastUpdated, termInfo }) => {
           const classesMap = new Map(Object.entries(classes));

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -55,26 +55,22 @@ function useHydrant(): {
   };
 
   useEffect(() => {
-    fetchNoCache<LatestTermInfo>("latestTerm.json")
-    .then(
-      (latestTerm) => {
-        const params = new URLSearchParams(document.location.search);
-        const term = params.get("t") ?? latestTerm.semester.urlName;
-        fetchNoCache<SemesterData>(`${term}.json`)
-        .then(
-          ({ classes, lastUpdated, termInfo }) => {
-            const classesMap = new Map(Object.entries(classes));
-            const hydrantObj = new State(
-              classesMap,
-              new Term(termInfo),
-              lastUpdated,
-              latestTerm.semester.urlName,
-            );
-            hydrantRef.current = hydrantObj;
-            setLoading(false);
-            window.hydrant = hydrantObj;
-          }
-        )
+    fetchNoCache<LatestTermInfo>("latestTerm.json").then((latestTerm) => {
+      const params = new URLSearchParams(document.location.search);
+      const term = params.get("t") ?? latestTerm.semester.urlName;
+      fetchNoCache<SemesterData>(`${term}.json`)
+        .then(({ classes, lastUpdated, termInfo }) => {
+          const classesMap = new Map(Object.entries(classes));
+          const hydrantObj = new State(
+            classesMap,
+            new Term(termInfo),
+            lastUpdated,
+            latestTerm.semester.urlName,
+          );
+          hydrantRef.current = hydrantObj;
+          setLoading(false);
+          window.hydrant = hydrantObj;
+        })
         // TODO: - make this nicer, without the try/catch
         //       - actually redirect to a valid URL
         //       - redirect 's'->latestSpring, 'f'->latestFall, etc.
@@ -82,8 +78,7 @@ function useHydrant(): {
         .catch((error) => {
           if (error instanceof SyntaxError) {
             console.log(`Invalid term ${term}, showing latest term`);
-            fetchNoCache<SemesterData>("latest.json")
-            .then(
+            fetchNoCache<SemesterData>("latest.json").then(
               ({ classes, lastUpdated, termInfo }) => {
                 const classesMap = new Map(Object.entries(classes));
                 const hydrantObj = new State(
@@ -95,13 +90,12 @@ function useHydrant(): {
                 hydrantRef.current = hydrantObj;
                 setLoading(false);
                 window.hydrant = hydrantObj;
-              }
+              },
             );
           }
         });
-      }
-    );
-  }, []);      
+    });
+  }, []);
 
   const { colorMode, toggleColorMode } = useColorMode();
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -75,23 +75,14 @@ function useHydrant(): {
         window.hydrant = hydrantObj;
       } catch (error) {
         // TODO: - make this nicer, without the try/catch
-        //       - actually redirect to a valid URL
         //       - redirect 's'->latestSpring, 'f'->latestFall, etc.
         //       - have a visual cue if the term in the url is invalid
         if (error instanceof SyntaxError) {
-          console.log(`Invalid term ${term}, showing latest term`);
-          const { classes, lastUpdated, termInfo } =
-            await fetchNoCache<SemesterData>("latest.json");
-          const classesMap = new Map(Object.entries(classes));
-          const hydrantObj = new State(
-            classesMap,
-            new Term(termInfo),
-            lastUpdated,
-            latestTerm.semester.urlName,
-          );
-          hydrantRef.current = hydrantObj;
-          setLoading(false);
-          window.hydrant = hydrantObj;
+          // Redirect to the latest term, while storing the initially requested
+          // term in the "ti" parameter so that the user can be notified
+          params.delete("t");
+          params.set("ti", term);
+          window.location.search = params.toString();
         }
       }
     };

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -86,8 +86,6 @@ function useHydrant(): {
         setLoading(false);
         window.hydrant = hydrantObj;
       } else {
-        // TODO: have a visual cue if the term in the url is invalid
-
         // Redirect to the indicated term, while storing the initially requested
         // term in the "ti" parameter (if necessary) so that the user can be
         // notified

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,5 @@
-import { Flex, Image } from "@chakra-ui/react";
+import { Card, IconButton, Flex, Image, Text } from "@chakra-ui/react";
+import { LuX } from "react-icons/lu";
 
 import {
   DialogRoot,
@@ -128,6 +129,19 @@ export function Header(props: { state: State; preferences: Preferences }) {
   const { state, preferences } = props;
   const logoSrc = useColorModeValue(logo, logoDark);
 
+  const params = new URLSearchParams(document.location.search);
+  const urlNameOrig = params.get("ti");
+  const urlName = params.get("t") ?? state.latestUrlName;
+
+  const [show, setShow] = useState(urlNameOrig !== null);
+
+  const onClose = () => {
+    const url = new URL(window.location.href);
+    url.searchParams.delete("ti");
+    window.history.pushState({}, "", url);
+    setShow(false);
+  };
+
   return (
     <Flex align="center" gap={3} wrap="wrap">
       <Flex direction="column" gap={1}>
@@ -143,6 +157,25 @@ export function Header(props: { state: State; preferences: Preferences }) {
         </Flex>
       </Flex>
       <PreferencesDialog preferences={preferences} state={state} />
+      {show && (
+        <Card.Root size="sm" variant="subtle">
+          <Card.Body px={3} py={1}>
+            <Flex align="center" gap={1.5}>
+              <Text fontSize="sm">
+                Term {urlNameOrig} not found; loaded term {urlName} instead.
+              </Text>
+              <IconButton
+                variant="subtle"
+                size="xs"
+                aria-label="Close"
+                onClick={onClose}
+              >
+                <LuX />
+              </IconButton>
+            </Flex>
+          </Card.Body>
+        </Card.Root>
+      )}
     </Flex>
   );
 }

--- a/src/components/TermSwitcher.tsx
+++ b/src/components/TermSwitcher.tsx
@@ -10,54 +10,7 @@ import {
 import { createListCollection } from "@chakra-ui/react";
 
 import { State } from "../lib/state";
-import { Term } from "../lib/dates";
-
-/** Given a urlName like i22, return its corresponding URL. */
-function toFullUrl(urlName: string, latestUrlName: string): string {
-  const url = new URL(window.location.href);
-  Array.from(url.searchParams.keys()).forEach((key) => {
-    url.searchParams.delete(key);
-  });
-  if (urlName !== latestUrlName) {
-    url.searchParams.set("t", urlName);
-  }
-  return url.href;
-}
-
-/** Given a urlName like "i22", return the previous one, "f21". */
-function getLastUrlName(urlName: string): string {
-  const { semester, year } = new Term({ urlName });
-  switch (semester) {
-    case "f":
-      return `m${year}`;
-    case "m":
-      return `s${year}`;
-    case "s":
-      return `i${year}`;
-    case "i":
-      return `f${parseInt(year, 10) - 1}`;
-  }
-}
-
-/** urlNames that don't have a State */
-const EXCLUDED_URLS = ["i23", "m23", "i24", "m24"];
-
-/** Earliest urlName we have a State for. */
-const EARLIEST_URL = "f22";
-
-/** Return all urlNames before the given one. */
-function getUrlNames(latestUrlName: string): Array<string> {
-  let urlName = latestUrlName;
-  const res = [];
-  while (urlName !== EARLIEST_URL) {
-    res.push(urlName);
-    do {
-      urlName = getLastUrlName(urlName);
-    } while (EXCLUDED_URLS.includes(urlName));
-  }
-  res.push(EARLIEST_URL);
-  return res;
-}
+import { Term, toFullUrl, getUrlNames } from "../lib/dates";
 
 export function TermSwitcher(props: { state: State }) {
   const { state } = props;

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -146,6 +146,53 @@ export function parseUrlName(urlName: string): {
   };
 }
 
+/** Given a urlName like i22, return its corresponding URL. */
+export function toFullUrl(urlName: string, latestUrlName: string): string {
+  const url = new URL(window.location.href);
+  Array.from(url.searchParams.keys()).forEach((key) => {
+    url.searchParams.delete(key);
+  });
+  if (urlName !== latestUrlName) {
+    url.searchParams.set("t", urlName);
+  }
+  return url.href;
+}
+
+/** Given a urlName like "i22", return the previous one, "f21". */
+function getLastUrlName(urlName: string): string {
+  const { semester, year } = new Term({ urlName });
+  switch (semester) {
+    case "f":
+      return `m${year}`;
+    case "m":
+      return `s${year}`;
+    case "s":
+      return `i${year}`;
+    case "i":
+      return `f${parseInt(year, 10) - 1}`;
+  }
+}
+
+/** urlNames that don't have a State */
+const EXCLUDED_URLS = ["i23", "m23", "i24", "m24"];
+
+/** Earliest urlName we have a State for. */
+const EARLIEST_URL = "f22";
+
+/** Return all urlNames before the given one. */
+export function getUrlNames(latestUrlName: string): Array<string> {
+  let urlName = latestUrlName;
+  const res = [];
+  while (urlName !== EARLIEST_URL) {
+    res.push(urlName);
+    do {
+      urlName = getLastUrlName(urlName);
+    } while (EXCLUDED_URLS.includes(urlName));
+  }
+  res.push(EARLIEST_URL);
+  return res;
+}
+
 /** Type of object passed to Term constructor. */
 export type TermInfo = {
   urlName: string;

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -173,6 +173,21 @@ function getLastUrlName(urlName: string): string {
   }
 }
 
+/** Given a urlName like "i22", return the next one, "s22". */
+function getNextUrlName(urlName: string): string {
+  const { semester, year } = new Term({ urlName });
+  switch (semester) {
+    case "i":
+      return `s${year}`;
+    case "s":
+      return `m${year}`;
+    case "m":
+      return `f${year}`;
+    case "f":
+      return `i${parseInt(year, 10) + 1}`;
+  }
+}
+
 /** urlNames that don't have a State */
 const EXCLUDED_URLS = ["i23", "m23", "i24", "m24"];
 
@@ -191,6 +206,48 @@ export function getUrlNames(latestUrlName: string): Array<string> {
   }
   res.push(EARLIEST_URL);
   return res;
+}
+
+/**
+ * Return the "closest" urlName to the one provided, as well as whether or not
+ * the user should be shown a warning that this does not match the term
+ * requested.
+ */
+export function getClosestUrlName(
+  urlName: string | null,
+  latestUrlName: string,
+): {
+  urlName: string;
+  shouldWarn: boolean;
+} {
+  if (urlName === null || urlName === "" || urlName === "latest") {
+    return { urlName: latestUrlName, shouldWarn: false };
+  }
+
+  const urlNames = getUrlNames(latestUrlName);
+  if (urlNames.includes(urlName)) {
+    return { urlName: urlName, shouldWarn: false };
+  }
+
+  // IAP or summer for a year where those were folded into spring/fall
+  if (EXCLUDED_URLS.includes(urlName)) {
+    const nextUrlName = getNextUrlName(urlName);
+    if (urlNames.includes(nextUrlName)) {
+      // modified: false because in these cases, e.g. s24 includes the data
+      // corresponding to i24
+      return { urlName: nextUrlName, shouldWarn: false };
+    }
+  }
+
+  const urlNamesSameSem = urlNames.filter((u) => u[0] === urlName[0]);
+  if (urlNamesSameSem.length > 0) {
+    // Unrecognized term, but we can return the latest term of the same type of
+    // semester (fall, spring, etc.)
+    return { urlName: urlNamesSameSem[0], shouldWarn: true };
+  }
+
+  // Fallback: return latest term
+  return { urlName: latestUrlName, shouldWarn: true };
 }
 
 /** Type of object passed to Term constructor. */


### PR DESCRIPTION
- It used to be loading forever if the term indicated by URL is invalid
- This is helpful for the new "View in Hydrant" feature for CourseRoad (https://github.com/sipb/courseroad2/issues/523) so CourseRoad doesn't have to worry about what is/isn't valid Hydrant term
- 

        // TODO: - make this nicer, without the try/catch
        //       - actually redirect to a valid URL
        //       - redirect 's'->latestSpring, 'f'->latestFall, etc.
        //       - have a visual cue if the term in the url is invalid