### PR TITLE
Add support for CI-M subjects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ dist-ssr
 scrapers/catalog.json
 scrapers/fireroad-sem.json
 scrapers/fireroad-presem.json
+scrapers/cim.json
 public/latest.json
 public/i25.json
 

--- a/scrapers/catalog.py
+++ b/scrapers/catalog.py
@@ -149,7 +149,7 @@ def get_home_catalog_links():
     Returns:
     * list[str]: relative links to major-specific subpages to scrape
     """
-    r = requests.get(BASE_URL + "/index.cgi", timeout=1)
+    r = requests.get(BASE_URL + "/index.cgi", timeout=3)
     html = BeautifulSoup(r.content, "html.parser")
     home_list = html.select_one("td[valign=top][align=left] > ul")
     return [a["href"] for a in home_list.find_all("a", href=True)]
@@ -167,7 +167,7 @@ def get_all_catalog_links(initial_hrefs):
     """
     hrefs = []
     for il in initial_hrefs:
-        r = requests.get(f"{BASE_URL}/{il}", timeout=1)
+        r = requests.get(f"{BASE_URL}/{il}", timeout=3)
         html = BeautifulSoup(r.content, "html.parser")
         # Links should be in the only table in the #contentmini div
         tables = html.find("div", id="contentmini").find_all("table")
@@ -214,7 +214,7 @@ def scrape_courses_from_page(courses, href):
 
     Returns: none
     """
-    r = requests.get(f"{BASE_URL}/{href}", timeout=1)
+    r = requests.get(f"{BASE_URL}/{href}", timeout=3)
     # The "html.parser" parses pretty badly
     html = BeautifulSoup(r.content, "lxml")
     classes_content = html.find("table", width="100%", border="0").find("td")

--- a/scrapers/cim.py
+++ b/scrapers/cim.py
@@ -1,0 +1,108 @@
+"""
+To include CI-M metadata, we scrape the Registrar's website which includes a
+list of all CI-M subjects for each course.
+
+run() scrapes this data and writes it to cim.json, in the format:
+
+{
+    "6.1800": {
+        "cim": [
+            "6-1, 6-2, 6-3, 6-4, 6-5, 6-P",
+            "10C",
+            "18-C",
+        ]
+    }
+}
+"""
+
+import itertools
+import json
+import requests
+from bs4 import BeautifulSoup
+from collections import OrderedDict
+
+
+def get_sections():
+    """
+    Scrapes accordion sections from
+    https://registrar.mit.edu/registration-academics/academic-requirements/communication-requirement/ci-m-subjects/subject
+
+    Args: none
+
+    Returns:
+    * list[bs4.element.Tag]: The accordion sections that contain lists of CI-M
+    subjects
+    """
+    r = requests.get(
+        "https://registrar.mit.edu/registration-academics/academic-requirements/communication-requirement/ci-m-subjects/subject",
+        timeout=1,
+    )
+    soup = BeautifulSoup(r.text, "html.parser")
+
+    return [
+        item
+        for item in soup.select("[data-accordion-item]")
+        if item.select(".ci-m__section")
+    ]
+
+
+def get_courses(section):
+    """
+    Extracts the courses contained in a section and their corresponding CI-M
+    subjects.
+
+    Args:
+    * section (bs4.element.Tag): from get_sections()
+
+    Returns:
+    * OrderedDict[str, set[str]]: A mapping from each course (major) contained
+    within the given section to the set of subject numbers (classes) that may
+    satisfy the CI-M requirement for that course number.
+    """
+    courses = OrderedDict()
+    for subsec in section.select(".ci-m__section"):
+        title = subsec.select_one(".ci-m__section-title").text.strip().replace("*", "")
+
+        # If no title, add to the previous subsection
+        if title:
+            subjects = set()
+        else:
+            title, subjects = courses.popitem()
+
+        subjects |= {
+            subj.text.strip() for subj in subsec.select(".ci-m__subject-number")
+        }
+        courses[title] = subjects
+    return courses
+
+
+def run():
+    """
+    The main entry point.
+
+    Args: none
+
+    Returns: none
+    """
+    sections = get_sections()
+
+    # This maps each course number to a set of CI-M subjects for that course
+    courses = OrderedDict()
+    for section in sections:
+        new_courses = get_courses(section)
+        assert new_courses.keys().isdisjoint(courses.keys())
+        courses.update(new_courses)
+
+    # This maps each subject to a list of courses for which it is a CI-M
+    subjects = {}
+    for course in courses:
+        for subj in courses[course]:
+            for number in subj.replace("J", "").split("/"):
+                subjects.setdefault(number, {"cim": []})["cim"].append(course)
+
+    with open("cim.json", "w", encoding="utf-8") as f:
+        json.dump(subjects, f)
+
+
+if __name__ == "__main__":
+    run()

--- a/scrapers/cim.py
+++ b/scrapers/cim.py
@@ -15,17 +15,17 @@ run() scrapes this data and writes it to cim.json, in the format:
 }
 """
 
-import itertools
 import json
 import requests
 from bs4 import BeautifulSoup
 from collections import OrderedDict
 
+CIM_URL = "https://registrar.mit.edu/registration-academics/academic-requirements/communication-requirement/ci-m-subjects/subject"
+
 
 def get_sections():
     """
-    Scrapes accordion sections from
-    https://registrar.mit.edu/registration-academics/academic-requirements/communication-requirement/ci-m-subjects/subject
+    Scrapes accordion sections from Registrar page that contains lists of CI-M
 
     Args: none
 
@@ -34,7 +34,7 @@ def get_sections():
     subjects
     """
     r = requests.get(
-        "https://registrar.mit.edu/registration-academics/academic-requirements/communication-requirement/ci-m-subjects/subject",
+        CIM_URL,
         timeout=1,
     )
     soup = BeautifulSoup(r.text, "html.parser")

--- a/scrapers/overrides.toml.d/override-schema.json
+++ b/scrapers/overrides.toml.d/override-schema.json
@@ -133,6 +133,13 @@
         "type": "boolean",
         "description": "True if partial institute lab"
       },
+      "cim": {
+        "type": "array",
+        "description": "Array of programs (free text) for which this class is a CI-M",
+        "items": {
+          "type": "string"
+        }
+      },
       "lectureUnits": {
         "type": "number",
         "description": "Lecture or recitation units"

--- a/scrapers/package.py
+++ b/scrapers/package.py
@@ -87,17 +87,18 @@ def run():
     fireroad_presem = load_json_data("fireroad-presem.json")
     fireroad_sem = load_json_data("fireroad-sem.json")
     catalog = load_json_data("catalog.json")
+    cim = load_json_data("cim.json")
     overrides = load_toml_data("overrides.toml.d")
 
     # The key needs to be in BOTH fireroad and catalog to make it:
     # If it's not in Fireroad, it's not offered in this semester (fall, etc.).
     # If it's not in catalog, it's not offered this year.
     courses_presem = merge_data(
-        datasets=[fireroad_presem, catalog, overrides],
+        datasets=[fireroad_presem, catalog, cim, overrides],
         keys_to_keep=set(fireroad_presem) & set(catalog),
     )
     courses_sem = merge_data(
-        datasets=[fireroad_sem, catalog, overrides],
+        datasets=[fireroad_sem, catalog, cim, overrides],
         keys_to_keep=set(fireroad_sem) & set(catalog),
     )
 

--- a/scrapers/update.py
+++ b/scrapers/update.py
@@ -9,6 +9,7 @@ Functions:
 
 import fireroad
 import catalog
+import cim
 import package
 
 
@@ -22,6 +23,8 @@ def run():
     fireroad.run(True)
     print("=== Update catalog data ===")
     catalog.run()
+    print("=== Update CI-M data ===")
+    cim.run()
     print("=== Packaging ===")
     package.run()
 

--- a/src/components/ActivityDescription.tsx
+++ b/src/components/ActivityDescription.tsx
@@ -147,7 +147,7 @@ function ClassCIM(props: { cls: Class }) {
       </Text>
     );
   } else {
-    return <></>;
+    return null;
   }
 }
 

--- a/src/components/ActivityDescription.tsx
+++ b/src/components/ActivityDescription.tsx
@@ -128,6 +128,29 @@ function ClassRelated(props: { cls: Class; state: State }) {
   );
 }
 
+/** List of programs for which this class is a CI-M. */
+function ClassCIM(props: { cls: Class }) {
+  const { cls } = props;
+  const { cim } = cls;
+
+  const url =
+    "https://registrar.mit.edu/registration-academics/academic-requirements/communication-requirement/ci-m-subjects/subject";
+
+  if (cim.length > 0) {
+    return (
+      <Text>
+        CI-M for: {cim.join("; ")} (
+        <Link href={url} target="_blank" colorPalette="blue">
+          more info
+        </Link>
+        )
+      </Text>
+    );
+  } else {
+    return <></>;
+  }
+}
+
 /** Class evaluation info. */
 function ClassEval(props: { cls: Class }) {
   const { cls } = props;
@@ -185,6 +208,7 @@ function ClassDescription(props: { cls: Class; state: State }) {
       <Flex direction="column" gap={0.5}>
         <ClassTypes cls={cls} state={state} />
         <ClassRelated cls={cls} state={state} />
+        <ClassCIM cls={cls} />
         <ClassEval cls={cls} />
       </Flex>
       <ClassButtons cls={cls} state={state} />

--- a/src/components/ClassTable.tsx
+++ b/src/components/ClassTable.tsx
@@ -210,6 +210,7 @@ const CLASS_FLAGS_1: FilterGroup = [
   ["starred", "Starred", <LuStar fill="currentColor" />],
   ["hass", "HASS"],
   ["cih", "CI-H"],
+  ["cim", "CI-M"],
   ["fits", "Fits schedule"],
   ["nofinal", "No final"],
   ["nopreq", "No prereq"],

--- a/src/components/ClassTable.tsx
+++ b/src/components/ClassTable.tsx
@@ -212,21 +212,25 @@ const CLASS_FLAGS_1: FilterGroup = [
   ["cih", "CI-H"],
   ["cim", "CI-M"],
   ["fits", "Fits schedule"],
-  ["nofinal", "No final"],
-  ["nopreq", "No prereq"],
 ];
 
 /** List of hidden filter IDs, their displayed names, and image path, if any. */
 const CLASS_FLAGS_2: FilterGroup = [
+  ["nofinal", "No final"],
+  ["nopreq", "No prereq"],
   ["under", "Undergrad", getFlagImg("under")],
   ["grad", "Graduate", getFlagImg("grad")],
+];
+
+/** Second row of hidden filter IDs. */
+const CLASS_FLAGS_3: FilterGroup = [
   ["le9units", "≤ 9 units"],
   ["half", "Half-term"],
   ["limited", "Limited enrollment"],
 ];
 
-/** Second row of hidden filter IDs. */
-const CLASS_FLAGS_3: FilterGroup = [
+/** Third row of hidden filter IDs. */
+const CLASS_FLAGS_4: FilterGroup = [
   ["rest", "REST", getFlagImg("rest")],
   ["Lab", "Institute Lab", getFlagImg("Lab")],
   ["hassA", "HASS-A", getFlagImg("hassA")],
@@ -236,7 +240,9 @@ const CLASS_FLAGS_3: FilterGroup = [
   ["notcih", "Not CI-H"],
 ];
 
-const CLASS_FLAGS = CLASS_FLAGS_1.concat(CLASS_FLAGS_2).concat(CLASS_FLAGS_3);
+const CLASS_FLAGS = CLASS_FLAGS_1.concat(CLASS_FLAGS_2)
+  .concat(CLASS_FLAGS_3)
+  .concat(CLASS_FLAGS_4);
 
 /** Div containing all the flags like "HASS". Maintains the flag filter. */
 function ClassFlags(props: {
@@ -370,6 +376,7 @@ function ClassFlags(props: {
         <>
           {renderGroup(CLASS_FLAGS_2)}
           {renderGroup(CLASS_FLAGS_3)}
+          {renderGroup(CLASS_FLAGS_4)}
         </>
       )}
     </Flex>

--- a/src/components/ClassTable.tsx
+++ b/src/components/ClassTable.tsx
@@ -201,9 +201,8 @@ function ClassInput(props: {
   );
 }
 
-type FilterGroup = Array<
-  [keyof Flags | "fits" | "starred", string, React.ReactNode?]
->;
+type Filter = keyof Flags | "fits" | "starred";
+type FilterGroup = Array<[Filter, string, React.ReactNode?]>;
 
 /** List of top filter IDs and their displayed names. */
 const CLASS_FLAGS_1: FilterGroup = [
@@ -240,9 +239,12 @@ const CLASS_FLAGS_4: FilterGroup = [
   ["notcih", "Not CI-H"],
 ];
 
-const CLASS_FLAGS = CLASS_FLAGS_1.concat(CLASS_FLAGS_2)
-  .concat(CLASS_FLAGS_3)
-  .concat(CLASS_FLAGS_4);
+const CLASS_FLAGS = [
+  ...CLASS_FLAGS_1,
+  ...CLASS_FLAGS_2,
+  ...CLASS_FLAGS_3,
+  ...CLASS_FLAGS_4,
+];
 
 /** Div containing all the flags like "HASS". Maintains the flag filter. */
 function ClassFlags(props: {
@@ -255,9 +257,7 @@ function ClassFlags(props: {
   const { setFlagsFilter, state, updateFilter } = props;
 
   // Map from flag to whether it's on.
-  const [flags, setFlags] = useState<
-    Map<keyof Flags | "fits" | "starred", boolean>
-  >(() => {
+  const [flags, setFlags] = useState<Map<Filter, boolean>>(() => {
     const result = new Map();
     for (const flag of CLASS_FLAGS) {
       result.set(flag, false);
@@ -274,7 +274,7 @@ function ClassFlags(props: {
     state.fitsScheduleCallback = () => flags.get("fits") && updateFilter();
   }, [state, flags, updateFilter]);
 
-  const onChange = (flag: keyof Flags | "fits" | "starred", value: boolean) => {
+  const onChange = (flag: Filter, value: boolean) => {
     const newFlags = new Map(flags);
     newFlags.set(flag, value);
     setFlags(newFlags);
@@ -367,7 +367,6 @@ function ClassFlags(props: {
       <Flex align="center">
         {renderGroup(CLASS_FLAGS_1)}
         <Button onClick={() => setAllFlags(!allFlags)} size="sm" ml={2}>
-          {" "}
           {allFlags ? <LuMinus /> : <LuPlus />}
           {allFlags ? "Less filters" : "More filters"}
         </Button>

--- a/src/components/ui/provider.tsx
+++ b/src/components/ui/provider.tsx
@@ -20,10 +20,12 @@ const system = createSystem(defaultConfig, {
     },
     recipes: {
       button: {
+        base: {
+          fontWeight: "semibold",
+        },
         defaultVariants: {
           // @ts-expect-error: this works I promise :(
           variant: "subtle",
-          fontweight: "semibold",
         },
       },
     },

--- a/src/lib/class.ts
+++ b/src/lib/class.ts
@@ -50,6 +50,7 @@ export type Flags = {
   cih: boolean;
   cihw: boolean;
   notcih: boolean;
+  cim: boolean;
   final: boolean;
   nofinal: boolean;
   nopreq: boolean;
@@ -375,6 +376,7 @@ export class Class {
       cih: this.rawClass.cih,
       cihw: this.rawClass.cihw,
       notcih: !this.rawClass.cih && !this.rawClass.cihw,
+      cim: !!this.rawClass.cim?.length,
       final: this.rawClass.final,
       nofinal: !this.rawClass.final,
       nopreq: this.rawClass.prereqs === "None",

--- a/src/lib/class.ts
+++ b/src/lib/class.ts
@@ -386,6 +386,11 @@ export class Class {
     };
   }
 
+  /** Array of programs (free text) for which this class is a CI-M */
+  get cim(): Array<string> {
+    return this.rawClass.cim ?? [];
+  }
+
   /** Evals, or N/A if non-existent. */
   get evals(): {
     rating: string;

--- a/src/lib/rawClass.ts
+++ b/src/lib/rawClass.ts
@@ -55,6 +55,9 @@ export type RawClass = {
   /** True if partial institute lab */
   partLab: boolean;
 
+  /** Array of programs (free text) for which this class is a CI-M */
+  cim?: Array<string>;
+
   /** Lecture or recitation units */
   lectureUnits: number;
   /** Lab or field work units */


### PR DESCRIPTION
Fixes #125. Scrape the lists of CI-M subjects from [the Registrar](https://registrar.mit.edu/registration-academics/academic-requirements/communication-requirement/ci-m-subjects/subject) and include this informaion in our model to provide a "CI-M" filter as well as an indication that a class is a CI-M in one or more departments.

Two potential points of discussion:
- `cim` is now the only optional field in `RawClass`; I think this is fine since it's explicitly documented in the type, but it may be a good idea to make it mandatory and fill it in with the empty list for classes that are not CI-Ms.
- The "CI-M" filter matches any class that is a CI-M for any program. It's still manageable to use since the total number of CI-Ms is low and they are sorted by course number, but it may be a good idea to make the filter a dropdown that allows selection of a particular program (especially since some departments permit out-of-department CI-Ms).

![image](https://github.com/user-attachments/assets/fea37b95-a1bf-41db-9029-afbd70bcb56f)