### PR TITLE
Fix class table width & height

### DIFF
--- a/src/components/ClassTable.scss
+++ b/src/components/ClassTable.scss
@@ -1,3 +1,7 @@
+.ag-root {
+  width: 100%;
+}
+
 .ag-row {
   cursor: pointer;
 }

--- a/src/components/ClassTable.tsx
+++ b/src/components/ClassTable.tsx
@@ -539,7 +539,7 @@ export function ClassTable(props: {
         state={state}
         updateFilter={() => gridRef.current?.api?.onFilterChanged()}
       />
-      <Box style={{ height: "320px", width: "100%" }}>
+      <Box style={{ height: "320px", width: "100%", overflow: 'auto' }}>
         <AgGridReact<ClassTableRow>
           theme={hydrantTheme}
           ref={gridRef}

--- a/src/components/ClassTable.tsx
+++ b/src/components/ClassTable.tsx
@@ -539,7 +539,7 @@ export function ClassTable(props: {
         state={state}
         updateFilter={() => gridRef.current?.api?.onFilterChanged()}
       />
-      <Box style={{ height: "320px", width: "100%", overflow: 'auto' }}>
+      <Box style={{ height: "320px", width: "100%", overflow: "auto" }}>
         <AgGridReact<ClassTableRow>
           theme={hydrantTheme}
           ref={gridRef}


### PR DESCRIPTION
## Description
For some mysterious reason, the class table grid is overflowing. This hides class details that are shown when a row is clicked.

On viewpoint of certain sizes, the grid may not take up 100% of the width.

## Note
I write "mysterious" because I read from their [official docs](https://www.ag-grid.com/react-data-grid/deep-dive/#configure-the-grid) that the `<AgGridReact>` is supposed to fit to the parent div's height and width. In our case, that div is a `<Box>` with height 320px and width 100%. `<AgGridReact>` ignores that... On the contrary, this [page](https://www.ag-grid.com/react-data-grid/grid-size/) in the docs hints us to use `style` of `<AgGridReact>` which doesn't exist now (according to the Typescript spec). Hence, it is also possible that this is a bug with ag-grid (since we're using the latest 33.0.4 now) but unfortunately I don't have time to investigate...

## Screenshots
<img width="49%" alt="螢幕截圖 2025-01-31 下午12 25 31" src="https://github.com/user-attachments/assets/ce0af98b-082e-4429-9834-472801b57eff" />
<img width="49%" alt="螢幕截圖 2025-01-31 下午12 25 51" src="https://github.com/user-attachments/assets/35038649-4c64-495a-a706-583a8e2ea5b2" />

Before v.s. After
(Safari 16.4, on my Apple M2 MacBook Pro, Ventura 13.3.1)
