### PR TITLE
Display semester half hours as Q1/Q2 or Q3/Q4 based on semester

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -276,6 +276,8 @@ function HydrantApp() {
                 selectedActivities={state.selectedActivities}
                 units={state.units}
                 hours={state.hours}
+                hoursFirstHalf={state.hoursFirstHalf}
+                hoursSecondHalf={state.hoursSecondHalf}
                 warnings={state.warnings}
                 state={hydrant}
               />

--- a/src/components/SelectedActivities.tsx
+++ b/src/components/SelectedActivities.tsx
@@ -47,16 +47,29 @@ export function SelectedActivities(props: {
   selectedActivities: Array<Activity>;
   units: number;
   hours: number;
+  hoursFirstHalf: number;
+  hoursSecondHalf: number;
   warnings: Array<string>;
   state: State;
 }) {
-  const { selectedActivities, units, hours, warnings, state } = props;
+  const { selectedActivities, units, hours, hoursFirstHalf, hoursSecondHalf, warnings, state } = props;
+
+  const formatHours = () => {
+    if (hoursFirstHalf === hoursSecondHalf) {
+      return `${hours.toFixed(1)} hours`;
+    }
+    
+    // Use Q1/Q2 for fall semester, Q3/Q4 for spring semester
+    const [firstLabel, secondLabel] = state.term.semester === 'f' ? ['Q1', 'Q2'] : ['Q3', 'Q4'];
+    
+    return `\u2264 ${hours.toFixed(1)} hours (${hoursFirstHalf.toFixed(1)} ${firstLabel}, ${hoursSecondHalf.toFixed(1)} ${secondLabel})`;
+  };
 
   return (
     <Flex direction="column" gap={2}>
       <Flex gap={8} justify="center">
         <Text>{units} units</Text>
-        <Text>{hours.toFixed(1)} hours</Text>
+        <Text>{formatHours()}</Text>
       </Flex>
       <ButtonGroup gap={0} wrap="wrap">
         {selectedActivities.map((activity) => (

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -33,6 +33,8 @@ export type HydrantState = {
   totalOptions: number;
   units: number;
   hours: number;
+  hoursFirstHalf: number;
+  hoursSecondHalf: number;
   warnings: Array<string>;
   saveId: string;
   saves: Array<Save>;
@@ -47,6 +49,8 @@ export const DEFAULT_STATE: HydrantState = {
   totalOptions: 0,
   units: 0,
   hours: 0,
+  hoursFirstHalf: 0,
+  hoursSecondHalf: 0,
   warnings: [],
   saveId: "",
   saves: [],

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -196,13 +196,42 @@ export class State {
    * localStorage.
    */
   updateState(save: boolean = true): void {
+    // Calculate hours for each half
+    const firstHalfHours = sum(
+      this.selectedActivities
+        .filter(act => {
+          if ('rawClass' in act) {
+            // Include if class is full semester or first half
+            return !act.rawClass.half || act.rawClass.half === 1;
+          }
+          // Include all non-class activities in both halves
+          return true;
+        })
+        .map(activity => activity.hours)
+    );
+
+    const secondHalfHours = sum(
+      this.selectedActivities
+        .filter(act => {
+          if ('rawClass' in act) {
+            // Include if class is full semester or second half
+            return !act.rawClass.half || act.rawClass.half === 2;
+          }
+          // Include all non-class activities in both halves
+          return true;
+        })
+        .map(activity => activity.hours)
+    );
+
     this.callback?.({
       selectedActivities: this.selectedActivities,
       viewedActivity: this.viewedActivity,
       selectedOption: this.selectedOption,
       totalOptions: this.options.length,
       units: sum(this.selectedClasses.map((cls) => cls.totalUnits)),
-      hours: sum(this.selectedActivities.map((activity) => activity.hours)),
+      hours: Math.max(firstHalfHours, secondHalfHours), // Use max for total hours
+      hoursFirstHalf: firstHalfHours,
+      hoursSecondHalf: secondHalfHours,
       warnings: Array.from(
         new Set(this.selectedClasses.flatMap((cls) => cls.warnings.messages)),
       ),
@@ -210,6 +239,7 @@ export class State {
       saves: this.saves,
       preferences: this.preferences,
     });
+    
     if (save) {
       this.storeSave(this.saveId, false);
     }


### PR DESCRIPTION
Addresses issue #147 

- Updated state calculation to track hours separately for each semester half
- Modified display format to use Q1/Q2 or Q3/Q4 based on semester
