### PR TITLE
override 6.3900 URL with hydrant referral param

### DIFF
--- a/scrapers/overrides.toml.d/semester/6.toml
+++ b/scrapers/overrides.toml.d/semester/6.toml
@@ -1,4 +1,4 @@
 #:schema ../override-schema.json
 
 ["6.3900"]
-url = "https://introml.mit.edu/?from=hydrant"
+url = "https://introml.mit.edu?from=hydrant"


### PR DESCRIPTION
Hi! 

This PR adds a URL override for 6.3900 to use `https://introml.mit.edu?from=hydrant`.

I'm the instructor for 6.3900. I've requested the Registrar to use `https://introml.mit.edu?from=registrar` as course URL, and I'd like to do something similar here to understand traffic from Hydrant.