### PR TITLE
keep preferences dialog open on outside click (closes #18)

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -86,7 +86,9 @@ export function PreferencesDialog() {
           if (e.open) {
             onOpen();
           } else {
-            onCancel();
+            // Dismissing the dialog (ESC / click outside) keeps the previewed
+            // preferences; the explicit Cancel button reverts.
+            onConfirm();
           }
         }}
       >
@@ -195,9 +197,7 @@ export function PreferencesDialog() {
                 </Flex>
               </Dialog.Body>
               <Dialog.Footer>
-                <Dialog.ActionTrigger asChild>
-                  <Button>Cancel</Button>
-                </Dialog.ActionTrigger>
+                <Button onClick={onCancel}>Cancel</Button>
                 <Button onClick={onConfirm}>Save</Button>
               </Dialog.Footer>
             </Dialog.Content>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -93,6 +93,7 @@ export function PreferencesDialog() {
       <Dialog.Root
         open={visible}
         closeOnInteractOutside={false}
+        closeOnEscape={false}
         onInteractOutside={() => {
           // Clicking outside is easy to do by accident, so don't dismiss.
           // Give a quick nudge instead so it's clear the click was ignored.
@@ -119,9 +120,7 @@ export function PreferencesDialog() {
           <Dialog.Positioner>
             <Dialog.Content
               animation={
-                shaking
-                  ? { _motionSafe: `${shake} 0.3s ease-in-out` }
-                  : undefined
+                shaking ? { _motionSafe: `${shake} 0.3s ease-in-out` } : "none"
               }
             >
               <Dialog.Header>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useContext } from "react";
 import { useSearchParams } from "react-router";
+import { keyframes } from "@emotion/react";
 
 import {
   Card,
@@ -27,11 +28,20 @@ import logoDark from "../assets/logo-dark.svg";
 import hydraAnt from "../assets/hydraAnt.png";
 import { SIPBLogo } from "./ButtonsLinks";
 
+// Brief nudge when someone clicks outside the dialog, to hint that the click
+// was ignored rather than just doing nothing. Skipped under reduced motion.
+const shake = keyframes`
+  0%, 100% { transform: translateX(0); }
+  20%, 60% { transform: translateX(-4px); }
+  40%, 80% { transform: translateX(4px); }
+`;
+
 export function PreferencesDialog() {
   const { state, hydrantState } = useContext(HydrantContext);
   const { preferences: originalPreferences } = hydrantState;
 
   const [visible, setVisible] = useState(false);
+  const [shaking, setShaking] = useState(false);
   const [preferences, setPreferences] = useState(DEFAULT_PREFERENCES);
   const initialPreferencesRef = useRef(DEFAULT_PREFERENCES);
   const initialPreferences = initialPreferencesRef.current;
@@ -82,13 +92,20 @@ export function PreferencesDialog() {
     <>
       <Dialog.Root
         open={visible}
+        closeOnInteractOutside={false}
+        onInteractOutside={() => {
+          // Clicking outside is easy to do by accident, so don't dismiss.
+          // Give a quick nudge instead so it's clear the click was ignored.
+          setShaking(true);
+          window.setTimeout(() => {
+            setShaking(false);
+          }, 300);
+        }}
         onOpenChange={(e) => {
           if (e.open) {
             onOpen();
           } else {
-            // Dismissing the dialog (ESC / click outside) keeps the previewed
-            // preferences; the explicit Cancel button reverts.
-            onConfirm();
+            onCancel();
           }
         }}
       >
@@ -100,7 +117,13 @@ export function PreferencesDialog() {
         <Portal>
           <Dialog.Backdrop />
           <Dialog.Positioner>
-            <Dialog.Content>
+            <Dialog.Content
+              animation={
+                shaking
+                  ? { _motionSafe: `${shake} 0.3s ease-in-out` }
+                  : undefined
+              }
+            >
               <Dialog.Header>
                 <Dialog.Title>Preferences</Dialog.Title>
               </Dialog.Header>
@@ -197,7 +220,9 @@ export function PreferencesDialog() {
                 </Flex>
               </Dialog.Body>
               <Dialog.Footer>
-                <Button onClick={onCancel}>Cancel</Button>
+                <Dialog.ActionTrigger asChild>
+                  <Button>Cancel</Button>
+                </Dialog.ActionTrigger>
                 <Button onClick={onConfirm}>Save</Button>
               </Dialog.Footer>
             </Dialog.Content>


### PR DESCRIPTION
Hi! Incoming MIT student here — found Hydrant while looking at tools I'll be using next year and wanted to send a small fix.

Closes #18.

Right now closing the preferences dialog by clicking outside or hitting ESC reverts your color scheme / measurement system change, which is jarring because the change is already previewed live while the dialog is open. This swaps that around: dismissing the dialog keeps the previewed prefs, and the explicit Cancel button still reverts (same as before).