### PR TITLE
chores

### DIFF
--- a/src/components/ActivityButtons.tsx
+++ b/src/components/ActivityButtons.tsx
@@ -1,3 +1,5 @@
+import { useLayoutEffect, useState, type SubmitEventHandler } from "react";
+
 import {
   Button,
   ButtonGroup,
@@ -13,12 +15,9 @@ import {
   Text,
   createListCollection,
   parseColor,
+  type ButtonProps,
 } from "@chakra-ui/react";
-import type { ComponentPropsWithRef, SubmitEventHandler } from "react";
-import { useLayoutEffect, useState } from "react";
-
 import { ColorPickerInput } from "./ui/colorpicker-input";
-
 import { LuCheck as CheckIcon, LuX as CloseIcon } from "react-icons/lu";
 import { Checkbox } from "./ui/checkbox";
 import { Field } from "./ui/field";
@@ -38,7 +37,7 @@ import { PESection } from "../lib/pe";
 import { Slot, TIMESLOT_STRINGS, WEEKDAY_STRINGS } from "../lib/dates";
 import { useHydrantContext } from "../lib/hydrant";
 
-interface ToggleButtonProps extends ComponentPropsWithRef<typeof Button> {
+interface ToggleButtonProps extends ButtonProps {
   active: boolean;
   handleClick: () => void;
 }

--- a/src/components/ActivityButtons.tsx
+++ b/src/components/ActivityButtons.tsx
@@ -69,6 +69,7 @@ function OverrideLocations(props: { secs: Sections }) {
   const { state } = useHydrantContext();
   const [isOverriding, setIsOverriding] = useState(false);
   const [room, setRoom] = useState(secs.roomOverride);
+
   const onRelocate = () => {
     setIsOverriding(true);
     setRoom(secs.roomOverride);
@@ -81,6 +82,7 @@ function OverrideLocations(props: { secs: Sections }) {
   const onCancel = () => {
     setIsOverriding(false);
   };
+
   return isOverriding ? (
     <Flex gap={1} mr={1} mt={2}>
       <Input
@@ -113,38 +115,40 @@ function OverrideLocations(props: { secs: Sections }) {
   );
 }
 
+const genSelected = (cls: Class | PEClass) =>
+  cls.sections.map((sections) =>
+    sections.locked
+      ? sections.selected
+        ? sections.selected.rawTime
+        : LockOption.None
+      : LockOption.Auto,
+  );
+
+const getLabel = (sec: SectionLockOption, humanReadable?: boolean) => {
+  if (sec === LockOption.Auto) {
+    return humanReadable ? "Auto (default)" : LockOption.Auto;
+  } else if (sec === LockOption.None) {
+    return LockOption.None;
+  } else if (!humanReadable) {
+    return sec.rawTime;
+  } else if (sec instanceof PESection) {
+    return `${sec.sectionNumber}: ${sec.parsedTime}`;
+  } else {
+    return sec.parsedTime;
+  }
+};
+
 /** Div containing section manual selection interface. */
 function ClassManualSections(props: { cls: Class | PEClass }) {
   const { cls } = props;
   const { state } = useHydrantContext();
-  const genSelected = (cls: Class | PEClass) =>
-    cls.sections.map((sections) =>
-      sections.locked
-        ? sections.selected
-          ? sections.selected.rawTime
-          : LockOption.None
-        : LockOption.Auto,
-    );
   const [selected, setSelected] = useState(genSelected(cls));
+
   useLayoutEffect(() => {
     setSelected(genSelected(cls));
   }, [cls]);
 
   const RenderOptions = () => {
-    const getLabel = (sec: SectionLockOption, humanReadable?: boolean) => {
-      if (sec === LockOption.Auto) {
-        return humanReadable ? "Auto (default)" : LockOption.Auto;
-      } else if (sec === LockOption.None) {
-        return LockOption.None;
-      } else if (!humanReadable) {
-        return sec.rawTime;
-      } else if (sec instanceof PESection) {
-        return `${sec.sectionNumber}: ${sec.parsedTime}`;
-      } else {
-        return sec.parsedTime;
-      }
-    };
-
     return (
       <>
         {cls.sections.map((secs, sectionIndex) => {
@@ -309,6 +313,10 @@ export function ClassButtons(props: { cls: Class | PEClass }) {
   );
 }
 
+const timesCollection = createListCollection({
+  items: TIMESLOT_STRINGS,
+});
+
 /** Form to add a timeslot to a custom activity. */
 function CustomActivityAddTime(props: { activity: CustomActivity }) {
   const { activity } = props;
@@ -349,10 +357,6 @@ function CustomActivityAddTime(props: { activity: CustomActivity }) {
       </>
     );
   };
-
-  const timesCollection = createListCollection({
-    items: TIMESLOT_STRINGS,
-  });
 
   const renderTimeDropdown = (key: "start" | "end") => (
     <Select.Root

--- a/src/components/ActivityButtons.tsx
+++ b/src/components/ActivityButtons.tsx
@@ -15,7 +15,7 @@ import {
   parseColor,
 } from "@chakra-ui/react";
 import type { ComponentPropsWithRef, SubmitEventHandler } from "react";
-import { useContext, useLayoutEffect, useState } from "react";
+import { useLayoutEffect, useState } from "react";
 
 import { ColorPickerInput } from "./ui/colorpicker-input";
 
@@ -36,7 +36,7 @@ import type { Class } from "../lib/class";
 import type { PEClass } from "../lib/pe";
 import { PESection } from "../lib/pe";
 import { Slot, TIMESLOT_STRINGS, WEEKDAY_STRINGS } from "../lib/dates";
-import { HydrantContext } from "../lib/hydrant";
+import { useHydrantContext } from "../lib/hydrant";
 
 interface ToggleButtonProps extends ComponentPropsWithRef<typeof Button> {
   active: boolean;
@@ -66,7 +66,7 @@ function ToggleButton({
 
 function OverrideLocations(props: { secs: Sections }) {
   const { secs } = props;
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
   const [isOverriding, setIsOverriding] = useState(false);
   const [room, setRoom] = useState(secs.roomOverride);
   const onRelocate = () => {
@@ -116,7 +116,7 @@ function OverrideLocations(props: { secs: Sections }) {
 /** Div containing section manual selection interface. */
 function ClassManualSections(props: { cls: Class | PEClass }) {
   const { cls } = props;
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
   const genSelected = (cls: Class | PEClass) =>
     cls.sections.map((sections) =>
       sections.locked
@@ -205,7 +205,7 @@ function ClassManualSections(props: { cls: Class | PEClass }) {
 /** Div containing color selection interface. */
 function ActivityColor(props: { activity: Activity; onHide: () => void }) {
   const { activity, onHide } = props;
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
   const initColor = parseColor(activity.backgroundColor);
   const [color, setColor] = useState(initColor);
 
@@ -258,7 +258,7 @@ function ActivityColor(props: { activity: Activity; onHide: () => void }) {
 /** Buttons in class description to add/remove class, and lock sections. */
 export function ClassButtons(props: { cls: Class | PEClass }) {
   const { cls } = props;
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
   const [showManual, setShowManual] = useState(false);
   const [showColors, setShowColors] = useState(false);
   const isSelected = state.isSelectedActivity(cls);
@@ -312,7 +312,7 @@ export function ClassButtons(props: { cls: Class | PEClass }) {
 /** Form to add a timeslot to a custom activity. */
 function CustomActivityAddTime(props: { activity: CustomActivity }) {
   const { activity } = props;
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
   const [days, setDays] = useState(
     Object.fromEntries(WEEKDAY_STRINGS.map((day) => [day, false])),
   );
@@ -410,7 +410,7 @@ function CustomActivityAddTime(props: { activity: CustomActivity }) {
  */
 export function CustomActivityButtons(props: { activity: CustomActivity }) {
   const { activity } = props;
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
 
   const isSelected = state.isSelectedActivity(activity);
   const [isRenaming, setIsRenaming] = useState(false);

--- a/src/components/ActivityDescription.tsx
+++ b/src/components/ActivityDescription.tsx
@@ -11,17 +11,15 @@ import {
 } from "@chakra-ui/react";
 import { useColorModeValue } from "./ui/color-mode";
 import { Tooltip } from "./ui/tooltip";
+import { LuExternalLink, LuStar } from "react-icons/lu";
+import { ClassButtons, CustomActivityButtons } from "./ActivityButtons";
 
 import { CustomActivity } from "../lib/activity";
 import type { Flags } from "../lib/class";
 import { Class, DARK_IMAGES, getFlagImg } from "../lib/class";
 import { linkClasses } from "../lib/utils";
 import { useHydrantContext } from "../lib/hydrant";
-
-import { ClassButtons, CustomActivityButtons } from "./ActivityButtons";
-import { LuExternalLink, LuStar } from "react-icons/lu";
-import { type PEFlags } from "../lib/pe";
-import { PEClass, getPEFlagEmoji } from "../lib/pe";
+import { PEClass, getPEFlagEmoji, type PEFlags } from "../lib/pe";
 
 /** A small image indicating a flag, like Spring or CI-H. */
 function ClassTypeSpan(props: { flag: keyof Flags; title: string }) {

--- a/src/components/ActivityDescription.tsx
+++ b/src/components/ActivityDescription.tsx
@@ -197,19 +197,19 @@ function ClassRelated(props: { cls: Class }) {
   );
 }
 
+const CIM_URL =
+  "https://registrar.mit.edu/registration-academics/academic-requirements/communication-requirement/ci-m-subjects/subject";
+
 /** List of programs for which this class is a CI-M. */
 function ClassCIM(props: { cls: Class }) {
   const { cls } = props;
   const { cim } = cls;
 
-  const url =
-    "https://registrar.mit.edu/registration-academics/academic-requirements/communication-requirement/ci-m-subjects/subject";
-
   if (cim.length > 0) {
     return (
       <Text>
         CI-M for: {cim.join("; ")} (
-        <Link href={url} target="_blank" colorPalette="blue">
+        <Link href={CIM_URL} target="_blank" colorPalette="blue">
           more info
         </Link>
         )
@@ -328,6 +328,11 @@ function CustomActivityDescription(props: { activity: CustomActivity }) {
   );
 }
 
+const fmt = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+});
+
 /** Full PE&W class description, from title to URLs at the end. */
 function PEClassDescription(props: { cls: PEClass }) {
   const { cls } = props;
@@ -336,12 +341,6 @@ function PEClassDescription(props: { cls: PEClass }) {
   const { fee, startDate, endDate } = cls;
   const { number, name, prereqs, equipment, quarter } = cls.rawClass;
   const { description } = cls.description;
-
-  const fmt = new Intl.DateTimeFormat("en-US", {
-    month: "short",
-    day: "numeric",
-    timeZone: "UTC",
-  });
 
   const start = fmt.format(startDate);
   const end = fmt.format(endDate);
@@ -434,6 +433,7 @@ function PEClassDescription(props: { cls: PEClass }) {
 export function ActivityDescription() {
   const { hydrantState } = useHydrantContext();
   const { viewedActivity: activity } = hydrantState;
+
   if (!activity) {
     return null;
   }

--- a/src/components/ActivityDescription.tsx
+++ b/src/components/ActivityDescription.tsx
@@ -1,4 +1,3 @@
-import { useContext } from "react";
 import { decode } from "html-entities";
 
 import {
@@ -17,7 +16,7 @@ import { CustomActivity } from "../lib/activity";
 import type { Flags } from "../lib/class";
 import { Class, DARK_IMAGES, getFlagImg } from "../lib/class";
 import { linkClasses } from "../lib/utils";
-import { HydrantContext } from "../lib/hydrant";
+import { useHydrantContext } from "../lib/hydrant";
 
 import { ClassButtons, CustomActivityButtons } from "./ActivityButtons";
 import { LuExternalLink, LuStar } from "react-icons/lu";
@@ -59,7 +58,7 @@ function PEClassTypeSpan(props: { flag: keyof PEFlags; title: string }) {
 /** Header for class description; contains flags and units. */
 function ClassTypes(props: { cls: Class }) {
   const { cls } = props;
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
   const { flags, totalUnits, units } = cls;
 
   /**
@@ -181,7 +180,7 @@ function PEClassTypes(props: { cls: PEClass }) {
 /** List of related classes, appears after flags and before description. */
 function ClassRelated(props: { cls: Class }) {
   const { cls } = props;
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
   const { prereq, same, meets } = cls.related;
 
   return (
@@ -238,7 +237,7 @@ function ClassEval(props: { cls: Class }) {
 /** Class description, person in-charge, and any URLs afterward. */
 function ClassBody(props: { cls: Class }) {
   const { cls } = props;
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
   const { description, inCharge, extraUrls } = cls.description;
 
   return (
@@ -270,7 +269,7 @@ function ClassBody(props: { cls: Class }) {
 /** Full class description, from title to URLs at the end. */
 function ClassDescription(props: { cls: Class }) {
   const { cls } = props;
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
   const isStarred = state.isClassStarred(cls);
 
   return (
@@ -305,7 +304,7 @@ function ClassDescription(props: { cls: Class }) {
 /** Full custom activity description, from title to timeslots. */
 function CustomActivityDescription(props: { activity: CustomActivity }) {
   const { activity } = props;
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
 
   return (
     <Flex direction="column" gap={4}>
@@ -332,7 +331,7 @@ function CustomActivityDescription(props: { activity: CustomActivity }) {
 /** Full PE&W class description, from title to URLs at the end. */
 function PEClassDescription(props: { cls: PEClass }) {
   const { cls } = props;
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
   const isStarred = state.isPEClassStarred(cls);
   const { fee, startDate, endDate } = cls;
   const { number, name, prereqs, equipment, quarter } = cls.rawClass;
@@ -433,7 +432,7 @@ function PEClassDescription(props: { cls: PEClass }) {
 
 /** Activity description, whether class, PE class, or custom activity. */
 export function ActivityDescription() {
-  const { hydrantState } = useContext(HydrantContext);
+  const { hydrantState } = useHydrantContext();
   const { viewedActivity: activity } = hydrantState;
   if (!activity) {
     return null;

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -11,7 +11,7 @@ import {
 } from "@chakra-ui/react";
 
 import { useHydrantContext } from "../lib/hydrant";
-import { BANNER_MESSAGE } from "~/lib/schema";
+import { BANNER_MESSAGE } from "../lib/schema";
 
 /** Main banner */
 export const AnnouncementsBanner = () => {

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -70,8 +70,9 @@ export const AnnouncementsBanner = () => {
 /** Unknown subjects warning, same style as banner */
 export const UnknownSubjectsBanner = () => {
   const { state } = useHydrantContext();
-  const unknownSubjects = Array.from(state.unknownSubjects);
   const [unknownVisible, setUnknownVisible] = useState(true);
+
+  const unknownSubjects = Array.from(state.unknownSubjects);
 
   return (
     <Presence

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from "react";
+import { useState } from "react";
 import {
   Center,
   Flex,
@@ -10,12 +10,12 @@ import {
   Stack,
 } from "@chakra-ui/react";
 
-import { HydrantContext } from "../lib/hydrant";
+import { useHydrantContext } from "../lib/hydrant";
 import { BANNER_MESSAGE } from "~/lib/schema";
 
 /** Main banner */
 export const AnnouncementsBanner = () => {
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
   return (
     <Presence
       present={state.showBanner}
@@ -69,7 +69,7 @@ export const AnnouncementsBanner = () => {
 
 /** Unknown subjects warning, same style as banner */
 export const UnknownSubjectsBanner = () => {
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
   const unknownSubjects = Array.from(state.unknownSubjects);
   const [unknownVisible, setUnknownVisible] = useState(true);
 

--- a/src/components/ButtonsLinks.tsx
+++ b/src/components/ButtonsLinks.tsx
@@ -17,7 +17,6 @@ import sipbLogo from "../assets/simple-fuzzball.png";
 
 export function ExportCalendar() {
   const { state } = useHydrantContext();
-
   const [isExporting, setIsExporting] = useState(false);
   // TODO: fix gcal export
   const onICSExport = useICSExport(
@@ -56,7 +55,7 @@ export function MatrixLink() {
     state: { selectedActivities },
   } = useHydrantContext();
 
-  // reference: https://github.com/gabrc52/class_group_chats/tree/main/src/routes/import
+  /** reference: https://github.com/gabrc52/class_group_chats/tree/main/src/routes/import */
   const matrixLink = `https://matrix.mit.edu/classes/import?via=Hydrant${selectedActivities
     .filter((activity) => activity instanceof Class)
     .map((cls) => `&class=${cls.number}`)

--- a/src/components/ButtonsLinks.tsx
+++ b/src/components/ButtonsLinks.tsx
@@ -16,11 +16,9 @@ import { Button, Image, Link as ChakraLink } from "@chakra-ui/react";
 import sipbLogo from "../assets/simple-fuzzball.png";
 
 export function ExportCalendar() {
-  const { state } = useHydrantContext();
   const [isExporting, setIsExporting] = useState(false);
   // TODO: fix gcal export
   const onICSExport = useICSExport(
-    state,
     () => {
       setIsExporting(false);
     },

--- a/src/components/ButtonsLinks.tsx
+++ b/src/components/ButtonsLinks.tsx
@@ -1,7 +1,7 @@
-import { useContext, useState } from "react";
+import { useState } from "react";
 
 import { Class } from "../lib/class";
-import { HydrantContext } from "../lib/hydrant";
+import { useHydrantContext } from "../lib/hydrant";
 import { useICSExport } from "../lib/gapi";
 
 import {
@@ -16,7 +16,7 @@ import { Button, Image, Link as ChakraLink } from "@chakra-ui/react";
 import sipbLogo from "../assets/simple-fuzzball.png";
 
 export function ExportCalendar() {
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
 
   const [isExporting, setIsExporting] = useState(false);
   // TODO: fix gcal export
@@ -54,7 +54,7 @@ export function ExportCalendar() {
 export function MatrixLink() {
   const {
     state: { selectedActivities },
-  } = useContext(HydrantContext);
+  } = useHydrantContext();
 
   // reference: https://github.com/gabrc52/class_group_chats/tree/main/src/routes/import
   const matrixLink = `https://matrix.mit.edu/classes/import?via=Hydrant${selectedActivities
@@ -84,7 +84,7 @@ export function MatrixLink() {
 export function PreregLink() {
   const {
     state: { selectedActivities },
-  } = useContext(HydrantContext);
+  } = useHydrantContext();
 
   // reference: https://github.com/gabrc52/class_group_chats/tree/main/src/routes/import
   const preregLink = `https://student.mit.edu/cgi-bin/sfprwtrm.sh?${selectedActivities

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from "react";
+import { useMemo } from "react";
 
 import { Circle, Float, Text } from "@chakra-ui/react";
 import { Tooltip } from "./ui/tooltip";
@@ -14,7 +14,7 @@ import interactionPlugin from "@fullcalendar/react/interaction";
 import type { Activity } from "../lib/activity";
 import { CustomActivity, Timeslot } from "../lib/activity";
 import { Slot } from "../lib/dates";
-import { HydrantContext } from "../lib/hydrant";
+import { useHydrantContext } from "../lib/hydrant";
 
 import "@fullcalendar/react/skeleton.css";
 import "@fullcalendar/react/themes/monarch/theme.css";
@@ -34,7 +34,7 @@ const USER_TZ = Temporal.Now.timeZoneId();
  * change the schedule option selected.
  */
 export function Calendar() {
-  const { state, hydrantState } = useContext(HydrantContext);
+  const { state, hydrantState } = useHydrantContext();
   const { selectedActivities, viewedActivity } = hydrantState;
 
   const events = useMemo(() => {

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -30,6 +30,24 @@ const WALKING_SPEED = 4.4;
 const USER_TZ = Temporal.Now.timeZoneId();
 
 /**
+ * get building number from a room string
+ */
+const getBuildingNumber = (room: string) =>
+  room.split("-")[0].trim().replace(/\+$/, "");
+
+/**
+ * Get the approximate distance of two coordinates
+ */
+const getDistance = (
+  location1: { x: number; y: number },
+  location2: { x: number; y: number },
+) => {
+  const dx = location1.x - location2.x;
+  const dy = location1.y - location2.y;
+  return Math.sqrt(dx * dx + dy * dy);
+};
+
+/**
  * Calendar showing all the activities, including the buttons on top that
  * change the schedule option selected.
  */
@@ -43,13 +61,10 @@ export function Calendar() {
       .flatMap((event) => event.eventInputs);
   }, [selectedActivities]);
 
-  const getBuildingNumber = (room: string) =>
-    room.split("-")[0].trim().replace(/\+$/, "");
-
   /**
    * Get the approximate distance (in feet) between two buildings on campus
    */
-  const getDistance = (building1: string, building2: string) => {
+  const getBuildingDistance = (building1: string, building2: string) => {
     // Get coordinates of each building
     const location1 = state.locations.get(building1);
     const location2 = state.locations.get(building2);
@@ -58,9 +73,7 @@ export function Calendar() {
       return undefined;
     }
 
-    const dx = location1.x - location2.x;
-    const dy = location1.y - location2.y;
-    return Math.sqrt(dx * dx + dy * dy);
+    return getDistance(location1, location2);
   };
 
   /**
@@ -94,7 +107,7 @@ export function Calendar() {
       const beforeBuilding = getBuildingNumber(beforeEvent.room);
 
       // Approximate distance (in feet) between the two buildings
-      const distance = getDistance(thisBuilding, beforeBuilding);
+      const distance = getBuildingDistance(thisBuilding, beforeBuilding);
 
       if (distance === undefined || distance < DISTANCE_WARNING_THRESHOLD) {
         continue;

--- a/src/components/ClassTable.tsx
+++ b/src/components/ClassTable.tsx
@@ -1,5 +1,4 @@
 import {
-  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -42,7 +41,7 @@ import type { Class, Flags } from "../lib/class";
 import { DARK_IMAGES, getFlagImg } from "../lib/class";
 import { classNumberMatch, classSort, simplifyString } from "../lib/utils";
 import type { TSemester } from "../lib/dates";
-import { HydrantContext } from "../lib/hydrant";
+import { useHydrantContext } from "../lib/hydrant";
 import type { State } from "../lib/state";
 import { ColorStyles } from "../lib/colors";
 
@@ -141,7 +140,7 @@ function ClassInput(props: {
   setInputFilter: SetClassFilter;
 }) {
   const { rowData, setInputFilter } = props;
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
 
   // State for textbox input.
   const [classInput, setClassInput] = useState("");
@@ -308,7 +307,7 @@ function ClassFlags(props: {
   updateFilter: () => void;
 }) {
   const { setFlagsFilter, updateFilter } = props;
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
 
   // Map from flag to whether it's on.
   const [flags, setFlags] = useState<Map<Filter, boolean>>(() => {
@@ -460,7 +459,7 @@ const StarButton = ({
   cls: Class;
   onStarToggle?: () => void;
 }) => {
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
   const isStarred = state.isClassStarred(cls);
 
   return (
@@ -481,7 +480,7 @@ const StarButton = ({
 
 /** The table of all classes, along with searching and filtering with flags. */
 export function ClassTable() {
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
   const { classes } = state;
 
   const gridRef = useRef<AgGridReact<ClassTableRow>>(null);

--- a/src/components/ClassTypes.tsx
+++ b/src/components/ClassTypes.tsx
@@ -1,12 +1,14 @@
+import { useState } from "react";
+
 import { Tabs } from "@chakra-ui/react";
-import { useContext, useState } from "react";
+import { LuGraduationCap, LuDumbbell } from "react-icons/lu";
+import type { IconType } from "react-icons/lib";
 
 import { ClassTable } from "./ClassTable";
 import { PEClassTable } from "./PEClassTable";
-import { ClassType } from "~/lib/schema";
-import { LuGraduationCap, LuDumbbell } from "react-icons/lu";
-import type { IconType } from "react-icons/lib";
-import { HydrantContext } from "~/lib/hydrant";
+
+import { ClassType } from "../lib/schema";
+import { useHydrantContext } from "../lib/hydrant";
 
 function classTypeComponents(termKeys: ClassType[]) {
   const obj = {} as Record<ClassType, [IconType, React.ComponentType]>;
@@ -23,7 +25,7 @@ function classTypeComponents(termKeys: ClassType[]) {
 }
 
 export const ClassTypesSwitcher = () => {
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
   const [currentTab, setCurrentTab] = useState(ClassType.ACADEMIC);
 
   const tabs = classTypeComponents([

--- a/src/components/Footers.tsx
+++ b/src/components/Footers.tsx
@@ -18,100 +18,98 @@ function AboutDialog() {
   const [visible, setVisible] = useState(false);
 
   return (
-    <>
-      <Dialog.Root
-        lazyMount
-        open={visible}
-        onOpenChange={(e) => {
-          setVisible(e.open);
-        }}
-      >
-        <Dialog.Trigger asChild>
-          <ChakraLink colorPalette="blue">About</ChakraLink>
-        </Dialog.Trigger>
-        <Portal>
-          <Dialog.Backdrop />
-          <Dialog.Positioner>
-            <Dialog.Content>
-              <Dialog.Header>
-                <Dialog.Title>Hydrant</Dialog.Title>
-              </Dialog.Header>
-              <Dialog.Body>
-                <Flex direction="column" gap={4}>
-                  <Text>
-                    Hydrant is a student-run class planner for MIT students,
-                    maintained by SIPB, the{" "}
-                    <ChakraLink colorPalette="blue" asChild>
-                      <Link
-                        to="https://sipb.mit.edu/"
-                        target="_blank"
-                        rel="noreferrer"
-                      >
-                        Student Information Processing Board
-                      </Link>
-                    </ChakraLink>
-                    .
-                  </Text>
-                  <Text>
-                    We welcome contributions! View the source code or file
-                    issues on{" "}
-                    <ChakraLink colorPalette="blue" asChild>
-                      <Link
-                        target="_blank"
-                        rel="noreferrer"
-                        to="https://github.com/sipb/hydrant"
-                      >
-                        GitHub
-                      </Link>
-                    </ChakraLink>
-                    , or come to a SIPB meeting and ask how to help.
-                  </Text>
-                  <Text>
-                    We'd like to thank CJ Quines '23 for creating Hydrant and
-                    Edward Fan '19 for creating{" "}
-                    <ChakraLink colorPalette="blue" asChild>
-                      <Link
-                        target="_blank"
-                        rel="noreferrer"
-                        to="https://firehose.guide/"
-                      >
-                        Firehose
-                      </Link>
-                    </ChakraLink>
-                    , the basis for Hydrant. We'd also like to thank the{" "}
-                    <ChakraLink colorPalette="blue" asChild>
-                      <Link
-                        target="_blank"
-                        rel="noreferrer"
-                        to="https://fireroad.mit.edu/"
-                      >
-                        FireRoad
-                      </Link>
-                    </ChakraLink>{" "}
-                    team and{" "}
-                    <ChakraLink colorPalette="blue" asChild>
-                      <Link
-                        target="_blank"
-                        rel="noreferrer"
-                        to="https://physicaleducationandwellness.mit.edu/"
-                      >
-                        DAPER
-                      </Link>
-                    </ChakraLink>{" "}
-                    for collaborating with us.
-                  </Text>
-                </Flex>
-              </Dialog.Body>
-              <Dialog.Footer>
-                <Dialog.ActionTrigger asChild>
-                  <Button>Close</Button>
-                </Dialog.ActionTrigger>
-              </Dialog.Footer>
-            </Dialog.Content>
-          </Dialog.Positioner>
-        </Portal>
-      </Dialog.Root>
-    </>
+    <Dialog.Root
+      lazyMount
+      open={visible}
+      onOpenChange={(e) => {
+        setVisible(e.open);
+      }}
+    >
+      <Dialog.Trigger asChild>
+        <ChakraLink colorPalette="blue">About</ChakraLink>
+      </Dialog.Trigger>
+      <Portal>
+        <Dialog.Backdrop />
+        <Dialog.Positioner>
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>Hydrant</Dialog.Title>
+            </Dialog.Header>
+            <Dialog.Body>
+              <Flex direction="column" gap={4}>
+                <Text>
+                  Hydrant is a student-run class planner for MIT students,
+                  maintained by SIPB, the{" "}
+                  <ChakraLink colorPalette="blue" asChild>
+                    <Link
+                      to="https://sipb.mit.edu/"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Student Information Processing Board
+                    </Link>
+                  </ChakraLink>
+                  .
+                </Text>
+                <Text>
+                  We welcome contributions! View the source code or file issues
+                  on{" "}
+                  <ChakraLink colorPalette="blue" asChild>
+                    <Link
+                      target="_blank"
+                      rel="noreferrer"
+                      to="https://github.com/sipb/hydrant"
+                    >
+                      GitHub
+                    </Link>
+                  </ChakraLink>
+                  , or come to a SIPB meeting and ask how to help.
+                </Text>
+                <Text>
+                  We'd like to thank CJ Quines '23 for creating Hydrant and
+                  Edward Fan '19 for creating{" "}
+                  <ChakraLink colorPalette="blue" asChild>
+                    <Link
+                      target="_blank"
+                      rel="noreferrer"
+                      to="https://firehose.guide/"
+                    >
+                      Firehose
+                    </Link>
+                  </ChakraLink>
+                  , the basis for Hydrant. We'd also like to thank the{" "}
+                  <ChakraLink colorPalette="blue" asChild>
+                    <Link
+                      target="_blank"
+                      rel="noreferrer"
+                      to="https://fireroad.mit.edu/"
+                    >
+                      FireRoad
+                    </Link>
+                  </ChakraLink>{" "}
+                  team and{" "}
+                  <ChakraLink colorPalette="blue" asChild>
+                    <Link
+                      target="_blank"
+                      rel="noreferrer"
+                      to="https://physicaleducationandwellness.mit.edu/"
+                    >
+                      DAPER
+                    </Link>
+                  </ChakraLink>{" "}
+                  for collaborating with us.
+                </Text>
+              </Flex>
+            </Dialog.Body>
+            <Dialog.Footer>
+              <Dialog.ActionTrigger asChild>
+                <Button>Close</Button>
+              </Dialog.ActionTrigger>
+            </Dialog.Footer>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+    </Dialog.Root>
   );
 }
 
@@ -119,75 +117,72 @@ function PrivacyPolicyDialog() {
   const [visible, setVisible] = useState(false);
 
   return (
-    <>
-      <Dialog.Root
-        open={visible}
-        onOpenChange={(e) => {
-          setVisible(e.open);
-        }}
-      >
-        <Dialog.Trigger asChild>
-          <ChakraLink colorPalette="blue">Privacy Policy</ChakraLink>
-        </Dialog.Trigger>
-        <Portal>
-          <Dialog.Backdrop />
-          <Dialog.Positioner>
-            <Dialog.Content>
-              <Dialog.Header>
-                <Dialog.Title>Privacy Policy</Dialog.Title>
-              </Dialog.Header>
-              <Dialog.Body>
-                <Flex direction="column" gap={4}>
-                  <Text>
-                    SIPB self-hosts an open-source analytics platform called{" "}
-                    <ChakraLink colorPalette="blue" asChild>
-                      <Link
-                        target="_blank"
-                        rel="noreferrer"
-                        to="https://plausible.io/"
-                      >
-                        Plausible Analytics
-                      </Link>
-                    </ChakraLink>{" "}
-                    to track usage of Hydrant. A{" "}
-                    <ChakraLink colorPalette="blue" asChild>
-                      <Link
-                        target="_blank"
-                        rel="noreferrer"
-                        to="https://plausible.io/data-policy"
-                      >
-                        limited amount of information
-                      </Link>
-                    </ChakraLink>
-                    , including page URLs, HTTP Referer strings, browser and
-                    operating system information, device type, and what city you
-                    are in, is sent anonymously for analytics purposes. No
-                    personally identifiable information is ever collected or
-                    stored, and none of this information ever leaves SIPB.
-                  </Text>
-                  <Text>
-                    No data is transmitted otherwise. That means that our
-                    servers do not store your class or calendar information, and
-                    all data stays on your device. If you never export your
-                    class data, such as to Matrix, we never send your data
-                    anywhere else.
-                  </Text>
-                  <Text>
-                    We do not, and will never, share any user data with third
-                    parties without your explicit consent.
-                  </Text>
-                </Flex>
-              </Dialog.Body>
-              <Dialog.Footer>
-                <Dialog.ActionTrigger asChild>
-                  <Button>Close</Button>
-                </Dialog.ActionTrigger>
-              </Dialog.Footer>
-            </Dialog.Content>
-          </Dialog.Positioner>
-        </Portal>
-      </Dialog.Root>
-    </>
+    <Dialog.Root
+      open={visible}
+      onOpenChange={(e) => {
+        setVisible(e.open);
+      }}
+    >
+      <Dialog.Trigger asChild>
+        <ChakraLink colorPalette="blue">Privacy Policy</ChakraLink>
+      </Dialog.Trigger>
+      <Portal>
+        <Dialog.Backdrop />
+        <Dialog.Positioner>
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>Privacy Policy</Dialog.Title>
+            </Dialog.Header>
+            <Dialog.Body>
+              <Flex direction="column" gap={4}>
+                <Text>
+                  SIPB self-hosts an open-source analytics platform called{" "}
+                  <ChakraLink colorPalette="blue" asChild>
+                    <Link
+                      target="_blank"
+                      rel="noreferrer"
+                      to="https://plausible.io/"
+                    >
+                      Plausible Analytics
+                    </Link>
+                  </ChakraLink>{" "}
+                  to track usage of Hydrant. A{" "}
+                  <ChakraLink colorPalette="blue" asChild>
+                    <Link
+                      target="_blank"
+                      rel="noreferrer"
+                      to="https://plausible.io/data-policy"
+                    >
+                      limited amount of information
+                    </Link>
+                  </ChakraLink>
+                  , including page URLs, HTTP Referer strings, browser and
+                  operating system information, device type, and what city you
+                  are in, is sent anonymously for analytics purposes. No
+                  personally identifiable information is ever collected or
+                  stored, and none of this information ever leaves SIPB.
+                </Text>
+                <Text>
+                  No data is transmitted otherwise. That means that our servers
+                  do not store your class or calendar information, and all data
+                  stays on your device. If you never export your class data,
+                  such as to Matrix, we never send your data anywhere else.
+                </Text>
+                <Text>
+                  We do not, and will never, share any user data with third
+                  parties without your explicit consent.
+                </Text>
+              </Flex>
+            </Dialog.Body>
+            <Dialog.Footer>
+              <Dialog.ActionTrigger asChild>
+                <Button>Close</Button>
+              </Dialog.ActionTrigger>
+            </Dialog.Footer>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+    </Dialog.Root>
   );
 }
 
@@ -195,62 +190,59 @@ function LicenseDialog() {
   const [visible, setVisible] = useState(false);
 
   return (
-    <>
-      <Dialog.Root
-        open={visible}
-        onOpenChange={(e) => {
-          setVisible(e.open);
-        }}
-      >
-        <Dialog.Trigger asChild>
-          <ChakraLink colorPalette="blue">Terms of Use</ChakraLink>
-        </Dialog.Trigger>
-        <Portal>
-          <Dialog.Backdrop />
-          <Dialog.Positioner>
-            <Dialog.Content>
-              <Dialog.Header>
-                <Dialog.Title>Terms of Use</Dialog.Title>
-              </Dialog.Header>
-              <Dialog.Body>
-                <Flex direction="column" gap={4}>
-                  <Text>
-                    Hydrant is created and maintained by the MIT Student
-                    Information Processing Board (SIPB) with the help of student
-                    volunteers.
-                  </Text>
-                  <Text>
-                    By using Hydrant, both for your own personal purposes or for
-                    your own software development, you agree that any software
-                    created using any element of Hydrant will be and shall
-                    forever remain open-source and free (as in freedom) for any
-                    purpose.
-                  </Text>
-                  <Text>
-                    See the{" "}
-                    <ChakraLink colorPalette="blue" asChild>
-                      <Link
-                        target="_blank"
-                        rel="noreferrer"
-                        to="https://github.com/sipb/hydrant#license"
-                      >
-                        official license
-                      </Link>
-                    </ChakraLink>{" "}
-                    on GitHub, and reach out to us if you have any questions!
-                  </Text>
-                </Flex>
-              </Dialog.Body>
-              <Dialog.Footer>
-                <Dialog.ActionTrigger asChild>
-                  <Button>Close</Button>
-                </Dialog.ActionTrigger>
-              </Dialog.Footer>
-            </Dialog.Content>
-          </Dialog.Positioner>
-        </Portal>
-      </Dialog.Root>
-    </>
+    <Dialog.Root
+      open={visible}
+      onOpenChange={(e) => {
+        setVisible(e.open);
+      }}
+    >
+      <Dialog.Trigger asChild>
+        <ChakraLink colorPalette="blue">Terms of Use</ChakraLink>
+      </Dialog.Trigger>
+      <Portal>
+        <Dialog.Backdrop />
+        <Dialog.Positioner>
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>Terms of Use</Dialog.Title>
+            </Dialog.Header>
+            <Dialog.Body>
+              <Flex direction="column" gap={4}>
+                <Text>
+                  Hydrant is created and maintained by the MIT Student
+                  Information Processing Board (SIPB) with the help of student
+                  volunteers.
+                </Text>
+                <Text>
+                  By using Hydrant, both for your own personal purposes or for
+                  your own software development, you agree that any software
+                  created using any element of Hydrant will be and shall forever
+                  remain open-source and free (as in freedom) for any purpose.
+                </Text>
+                <Text>
+                  See the{" "}
+                  <ChakraLink colorPalette="blue" asChild>
+                    <Link
+                      target="_blank"
+                      rel="noreferrer"
+                      to="https://github.com/sipb/hydrant#license"
+                    >
+                      official license
+                    </Link>
+                  </ChakraLink>{" "}
+                  on GitHub, and reach out to us if you have any questions!
+                </Text>
+              </Flex>
+            </Dialog.Body>
+            <Dialog.Footer>
+              <Dialog.ActionTrigger asChild>
+                <Button>Close</Button>
+              </Dialog.ActionTrigger>
+            </Dialog.Footer>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+    </Dialog.Root>
   );
 }
 

--- a/src/components/Footers.tsx
+++ b/src/components/Footers.tsx
@@ -11,8 +11,9 @@ import {
 } from "@chakra-ui/react";
 import { Link } from "react-router";
 
-import fuzzAndAnt from "../assets/fuzzAndAnt.png";
 import { useHydrantContext } from "../lib/hydrant";
+
+import fuzzAndAnt from "../assets/fuzzAndAnt.png";
 
 function AboutDialog() {
   const [visible, setVisible] = useState(false);

--- a/src/components/Footers.tsx
+++ b/src/components/Footers.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from "react";
+import { useState } from "react";
 
 import {
   Flex,
@@ -12,7 +12,7 @@ import {
 import { Link } from "react-router";
 
 import fuzzAndAnt from "../assets/fuzzAndAnt.png";
-import { HydrantContext } from "../lib/hydrant";
+import { useHydrantContext } from "../lib/hydrant";
 
 function AboutDialog() {
   const [visible, setVisible] = useState(false);
@@ -256,7 +256,7 @@ function LicenseDialog() {
 
 /** The footer on the bottom of the calendar. */
 export function LeftFooter() {
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
 
   return (
     <Flex direction="row" align="center" justify="center" gap={5}>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useContext } from "react";
+import { useState, useRef } from "react";
 import { useSearchParams } from "react-router";
 import { keyframes } from "@emotion/react";
 
@@ -21,7 +21,7 @@ import { COLOR_SCHEME_PRESETS } from "../lib/colors";
 import { MEASUREMENT_SYSTEM_PRESETS } from "../lib/measurement";
 import type { Preferences } from "../lib/schema";
 import { DEFAULT_PREFERENCES } from "../lib/schema";
-import { HydrantContext } from "../lib/hydrant";
+import { useHydrantContext } from "../lib/hydrant";
 
 import logo from "../assets/logo.svg";
 import logoDark from "../assets/logo-dark.svg";
@@ -37,7 +37,7 @@ const shake = keyframes`
 `;
 
 export function PreferencesDialog() {
-  const { state, hydrantState } = useContext(HydrantContext);
+  const { state, hydrantState } = useHydrantContext();
   const { preferences: originalPreferences } = hydrantState;
 
   const [visible, setVisible] = useState(false);
@@ -234,7 +234,7 @@ export function PreferencesDialog() {
 
 /** Header above the left column, with logo and semester selection. */
 export function Header() {
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
   const logoSrc = useColorModeValue(logo, logoDark);
   const [searchParams, setSearchParams] = useSearchParams();
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -36,6 +36,26 @@ const shake = keyframes`
   40%, 80% { transform: translateX(4px); }
 `;
 
+const colorSchemeCollection = createListCollection({
+  items: [
+    { label: "System Default", value: "" },
+    ...COLOR_SCHEME_PRESETS.map(({ name }) => ({
+      label: name,
+      value: name,
+    })),
+  ],
+});
+
+const measurementSystemCollection = createListCollection({
+  items: [
+    { label: "System Default", value: "" },
+    ...MEASUREMENT_SYSTEM_PRESETS.map(({ name }) => ({
+      label: name,
+      value: name,
+    })),
+  ],
+});
+
 export function PreferencesDialog() {
   const { state, hydrantState } = useHydrantContext();
   const { preferences: originalPreferences } = hydrantState;
@@ -67,26 +87,6 @@ export function PreferencesDialog() {
     state.setPreferences(preferences);
     setVisible(false);
   };
-
-  const colorSchemeCollection = createListCollection({
-    items: [
-      { label: "System Default", value: "" },
-      ...COLOR_SCHEME_PRESETS.map(({ name }) => ({
-        label: name,
-        value: name,
-      })),
-    ],
-  });
-
-  const measurementSystemCollection = createListCollection({
-    items: [
-      { label: "System Default", value: "" },
-      ...MEASUREMENT_SYSTEM_PRESETS.map(({ name }) => ({
-        label: name,
-        value: name,
-      })),
-    ],
-  });
 
   return (
     <>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,5 @@
 import { useState, useRef } from "react";
 import { useSearchParams } from "react-router";
-import { keyframes } from "@emotion/react";
 
 import {
   Card,
@@ -16,6 +15,7 @@ import {
 } from "@chakra-ui/react";
 import { useColorModeValue } from "./ui/color-mode";
 import { LuSettings, LuX } from "react-icons/lu";
+import { keyframes } from "@emotion/react";
 
 import { COLOR_SCHEME_PRESETS } from "../lib/colors";
 import { MEASUREMENT_SYSTEM_PRESETS } from "../lib/measurement";

--- a/src/components/PEClassTable.tsx
+++ b/src/components/PEClassTable.tsx
@@ -1,6 +1,5 @@
 // TODO factor out common pieces between ClassTable and PEClassTable
 import {
-  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -38,7 +37,7 @@ import { LuPlus, LuMinus, LuSearch, LuStar } from "react-icons/lu";
 
 import { type PEFlags, type PEClass, getPEFlagEmoji } from "../lib/pe";
 import { classNumberMatch, classSort, simplifyString } from "../lib/utils";
-import { HydrantContext } from "../lib/hydrant";
+import { useHydrantContext } from "../lib/hydrant";
 import type { State } from "../lib/state";
 import { ColorStyles } from "../lib/colors";
 
@@ -98,7 +97,7 @@ function ClassInput(props: {
   setInputFilter: SetClassFilter;
 }) {
   const { rowData, setInputFilter } = props;
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
 
   // State for textbox input.
   const [classInput, setClassInput] = useState("");
@@ -237,7 +236,7 @@ function ClassFlags(props: {
   updateFilter: () => void;
 }) {
   const { setFlagsFilter, updateFilter } = props;
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
 
   // Map from flag to whether it's on.
   const [flags, setFlags] = useState<Map<Filter, boolean>>(() => {
@@ -360,7 +359,7 @@ const StarButton = ({
   cls: PEClass;
   onStarToggle?: () => void;
 }) => {
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
   const isStarred = state.isPEClassStarred(cls);
 
   return (
@@ -381,7 +380,7 @@ const StarButton = ({
 
 /** The table of all classes, along with searching and filtering with flags. */
 export function PEClassTable() {
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
   const { peClasses } = state;
 
   const gridRef = useRef<AgGridReact<ClassTableRow>>(null);

--- a/src/components/ScheduleOption.tsx
+++ b/src/components/ScheduleOption.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 
 import { IconButton, Flex, CloseButton } from "@chakra-ui/react";
-
 import { LuArrowLeft, LuArrowRight } from "react-icons/lu";
+
 import { useHydrantContext } from "../lib/hydrant";
 import { Alert } from "./ui/alert";
 

--- a/src/components/ScheduleOption.tsx
+++ b/src/components/ScheduleOption.tsx
@@ -1,14 +1,14 @@
-import { useContext, useState } from "react";
+import { useState } from "react";
 
 import { IconButton, Flex, CloseButton } from "@chakra-ui/react";
 
 import { LuArrowLeft, LuArrowRight } from "react-icons/lu";
-import { HydrantContext } from "../lib/hydrant";
+import { useHydrantContext } from "../lib/hydrant";
 import { Alert } from "./ui/alert";
 
 export function ScheduleOption() {
   const [tooManyOptions, setTooManyOptions] = useState(true);
-  const { state, hydrantState } = useContext(HydrantContext);
+  const { state, hydrantState } = useHydrantContext();
   const { selectedOption, totalOptions } = hydrantState;
 
   return (

--- a/src/components/ScheduleSwitcher.tsx
+++ b/src/components/ScheduleSwitcher.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState, type ReactNode } from "react";
+
 import {
   Box,
   Flex,
@@ -11,13 +13,8 @@ import {
   Menu,
   Portal,
   Clipboard,
+  type ButtonProps,
 } from "@chakra-ui/react";
-import type { ComponentPropsWithoutRef, ReactNode } from "react";
-import { useContext, useEffect, useState } from "react";
-
-import type { Save } from "../lib/schema";
-import { HydrantContext } from "../lib/hydrant";
-
 import {
   LuCopy,
   LuEllipsis,
@@ -30,7 +27,10 @@ import {
   LuTrash2,
 } from "react-icons/lu";
 
-function SmallButton(props: ComponentPropsWithoutRef<"button">) {
+import type { Save } from "../lib/schema";
+import { useHydrantContext } from "../lib/hydrant";
+
+function SmallButton(props: ButtonProps) {
   const { children, ...otherProps } = props;
   return (
     <Button {...otherProps} variant="outline" size="sm">
@@ -41,7 +41,7 @@ function SmallButton(props: ComponentPropsWithoutRef<"button">) {
 
 function SelectWithWarn(props: { saveId: string; saves: Save[] }) {
   const { saveId, saves } = props;
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
   const [confirmSave, setConfirmSave] = useState("");
   const confirmName = saves.find((save) => save.id === confirmSave)?.name;
   const defaultScheduleId = state.defaultSchedule;
@@ -149,7 +149,7 @@ function DeleteDialog(props: {
   children: ReactNode;
 }) {
   const { saveId, name, children } = props;
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
   const [show, setShow] = useState(false);
 
   return (
@@ -193,7 +193,7 @@ function DeleteDialog(props: {
 
 function ExportDialog(props: { children: ReactNode }) {
   const { children } = props;
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
   const [show, setShow] = useState(false);
   const link = state.urlify();
 
@@ -240,7 +240,7 @@ function ExportDialog(props: { children: ReactNode }) {
 }
 
 export function ScheduleSwitcher() {
-  const { state, hydrantState } = useContext(HydrantContext);
+  const { state, hydrantState } = useHydrantContext();
   const { saves, saveId } = hydrantState;
 
   const currentName = saves.find((save) => save.id === saveId)?.name ?? "";

--- a/src/components/SelectedActivities.tsx
+++ b/src/components/SelectedActivities.tsx
@@ -13,11 +13,10 @@ import { Class } from "../lib/class";
 import { useHydrantContext } from "../lib/hydrant";
 
 export function ColorButton(props: ButtonProps & { color: string }) {
-  const { children, color, style, ...otherProps } = props;
+  const { children, color, ...otherProps } = props;
   const contractColor = textColor(color);
   return (
     <Button
-      {...otherProps}
       backgroundColor={color}
       _hover={{
         backgroundColor: `color-mix(in oklab, ${color} 92%, ${contractColor})`,
@@ -27,9 +26,7 @@ export function ColorButton(props: ButtonProps & { color: string }) {
       }}
       borderColor={color}
       color={contractColor}
-      style={{
-        ...style,
-      }}
+      {...otherProps}
     >
       {children}
     </Button>

--- a/src/components/SelectedActivities.tsx
+++ b/src/components/SelectedActivities.tsx
@@ -41,6 +41,7 @@ function ActivityButton(props: { activity: Activity }) {
   const { activity } = props;
   const { state } = useHydrantContext();
   const color = activity.backgroundColor;
+
   return (
     <ColorButton
       color={color}

--- a/src/components/SelectedActivities.tsx
+++ b/src/components/SelectedActivities.tsx
@@ -1,16 +1,18 @@
-import { Flex, Text, Button, ButtonGroup } from "@chakra-ui/react";
-import { useContext, type ComponentPropsWithoutRef } from "react";
+import {
+  Flex,
+  Text,
+  Button,
+  ButtonGroup,
+  type ButtonProps,
+} from "@chakra-ui/react";
+import { LuPlus } from "react-icons/lu";
 
 import type { Activity } from "../lib/activity";
 import { textColor } from "../lib/colors";
 import { Class } from "../lib/class";
-import { HydrantContext } from "../lib/hydrant";
+import { useHydrantContext } from "../lib/hydrant";
 
-import { LuPlus } from "react-icons/lu";
-
-export function ColorButton(
-  props: ComponentPropsWithoutRef<"button"> & { color: string },
-) {
+export function ColorButton(props: ButtonProps & { color: string }) {
   const { children, color, style, ...otherProps } = props;
   const contractColor = textColor(color);
   return (
@@ -37,7 +39,7 @@ export function ColorButton(
 /** A button representing a single, selected activity. */
 function ActivityButton(props: { activity: Activity }) {
   const { activity } = props;
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
   const color = activity.backgroundColor;
   return (
     <ColorButton
@@ -56,7 +58,7 @@ function ActivityButton(props: { activity: Activity }) {
 
 /** List of selected activities; one button for each activity. */
 export function SelectedActivities() {
-  const { state, hydrantState } = useContext(HydrantContext);
+  const { state, hydrantState } = useHydrantContext();
   const { selectedActivities, units, hours, warnings } = hydrantState;
 
   return (

--- a/src/components/TermSwitcher.tsx
+++ b/src/components/TermSwitcher.tsx
@@ -1,12 +1,10 @@
-import { useContext } from "react";
-
 import { createListCollection, Portal, Select } from "@chakra-ui/react";
 
 import { Term, toFullUrl, getUrlNames } from "../lib/dates";
-import { HydrantContext } from "../lib/hydrant";
+import { useHydrantContext } from "../lib/hydrant";
 
 export function TermSwitcher() {
-  const { state } = useContext(HydrantContext);
+  const { state } = useHydrantContext();
   const toUrl = (urlName: string) => toFullUrl(urlName, state.latestUrlName);
   const defaultValue = toUrl(state.term.urlName);
 

--- a/src/components/TermSwitcher.tsx
+++ b/src/components/TermSwitcher.tsx
@@ -5,6 +5,7 @@ import { useHydrantContext } from "../lib/hydrant";
 
 export function TermSwitcher() {
   const { state } = useHydrantContext();
+
   const toUrl = (urlName: string) => toFullUrl(urlName, state.latestUrlName);
   const defaultValue = toUrl(state.term.urlName);
 

--- a/src/lib/gapi.ts
+++ b/src/lib/gapi.ts
@@ -5,8 +5,8 @@ import { tzlib_get_ical_block } from "timezones-ical-library";
 
 import type { Activity } from "./activity";
 import type { Term } from "./dates";
-import type { State } from "./state";
 import { Class } from "./class";
+import { useHydrantContext } from "./hydrant";
 
 /** MIT's Timezone string. */
 const TIMEZONE = "America/New_York";
@@ -76,25 +76,26 @@ function toICalEvents(activity: Activity, term: Term): ICalEventData[] {
 
 /** Hook that returns an export calendar function. */
 export function useICSExport(
-  state: State | undefined,
   onSuccess?: () => void,
   onError?: () => void,
 ): () => void {
+  const { state } = useHydrantContext();
+
   return () => {
     const cal = new ICalCalendar({
-      name: `Hydrant: ${state?.term.niceName ?? ""}`,
+      name: `Hydrant: ${state.term.niceName}`,
       timezone: {
         name: TIMEZONE,
         generator: (zone) => tzlib_get_ical_block(zone)[0],
       },
-      events: state?.selectedActivities.flatMap((activity) =>
+      events: state.selectedActivities.flatMap((activity) =>
         toICalEvents(activity, state.term),
       ),
     });
     console.log(cal);
 
     try {
-      download(`${state?.term.urlName ?? ""}.ics`, cal.toString());
+      download(`${state.term.urlName}.ics`, cal.toString());
     } catch (_err) {
       onError?.();
     }

--- a/src/lib/hydrant.ts
+++ b/src/lib/hydrant.ts
@@ -1,4 +1,4 @@
-import { createContext, useEffect, useRef, useState } from "react";
+import { createContext, useContext, useEffect, useRef, useState } from "react";
 import { useColorMode } from "../components/ui/color-mode";
 
 import type { TermInfo } from "../lib/dates";
@@ -79,3 +79,5 @@ export const HydrantContext = createContext({
   hydrantState: DEFAULT_STATE,
   state: {} as State,
 });
+
+export const useHydrantContext = () => useContext(HydrantContext);


### PR DESCRIPTION
Mostly quality of life changes and things I noticed when cooking up #388. Including:

- Sorting imports (we may want to consider a linting rule for this. For now, I tried to group react stuff, UI imports, lib, and other components into their own little groups. Was kind of like that before, but not consistent).
- Moving constant values and helper functions out of components (if they don't depend on component values)
- useContext was almost always used with HydrantContext. Made a helper to reduce boilerplate
- Removed one last place where we pass state as a prop, probably left over from when switching to context.